### PR TITLE
(fix) O3-3503: Fix pagination of problem datasource fetch results

### DIFF
--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -67,7 +67,7 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
         setIsLoading(false);
         setItems([]);
       });
-  }, 300);
+  }, 1500);
 
   const processSearchableValues = (value) => {
     dataSource

--- a/src/datasources/concept-data-source.ts
+++ b/src/datasources/concept-data-source.ts
@@ -18,24 +18,11 @@ export class ConceptDataSource extends BaseOpenMRSDataSource {
         const urlParts = apiUrl.split('searchType=fuzzy');
         apiUrl = `${urlParts[0]}searchType=fuzzy&class=${config.class}&${urlParts[1]}`;
       } else {
-        const fetchAllConcepts = (): Promise<any[]> => {
-          const fetchConceptsByClass = (classUuid: string) => {
-            const urlParts = apiUrl.split('searchType=fuzzy');
-            const url = `${urlParts[0]}searchType=fuzzy&class=${classUuid}&${urlParts[1] || ''}`;
-            return openmrsFetch(url).then(({ data }) => {
-              return data.results;
-            });
-          };
-
-          return Promise.all(config.class.map(fetchConceptsByClass))
-            .then((results) => results.flat())
-            .catch((error) => {
-              console.error('Error fetching data:', error);
-              return [];
-            });
-        };
-
-        return fetchAllConcepts();
+        return openmrsFetch(searchTerm ? `${apiUrl}&q=${searchTerm}` : apiUrl).then(({ data }) => {
+          return data.results.filter(
+            (concept) => concept.conceptClass && config.class.includes(concept.conceptClass.uuid),
+          );
+        });
       }
     }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currently, the implementation of the problem data source fetches only 50 results due to pagination constraints. This limitation affects the visibility of data across three concept classes. This pull request aims to enhance the data fetching process to retrieve all results from the endpoint, ensuring comprehensive data coverage.

## Screenshots
<!-- Required if you are making UI changes. -->
https://github.com/openmrs/openmrs-form-engine-lib/assets/19533785/b81e82b4-6f04-4359-9486-7a1414d67096

## Related Issue

https://openmrs.atlassian.net/browse/O3-3503

## Other
<!-- Anything not covered above -->
