### PR TITLE
(fix) Fix patient banner

### DIFF
--- a/src/form-engine.component.tsx
+++ b/src/form-engine.component.tsx
@@ -3,7 +3,6 @@ import type { FormField, SessionMode, FormSchema } from './types';
 import { useSession, type Visit } from '@openmrs/esm-framework';
 import { useFormJson } from '.';
 import FormProcessorFactory from './components/processor-factory/form-processor-factory.component';
-import { Form } from '@carbon/react';
 import Loader from './components/loaders/loader.component';
 import { usePatientData } from './hooks/usePatientData';
 import { useWorkspaceLayout } from './hooks/useWorkspaceLayout';
@@ -66,12 +65,15 @@ const FormEngine = ({
   // TODO: Updating this prop triggers a rerender of the entire form. This means whenever we scroll into a new page, the form is rerendered.
   // Figure out a way to avoid this. Maybe use a ref with an observer instead of a state?
   const [currentPage, setCurrentPage] = useState('');
-  const [showPatientBanner, setShowPatientBanner] = useState(false);
   const {
     formJson: refinedFormJson,
     isLoading: isLoadingFormJson,
     formError,
   } = useFormJson(formUUID, formJson, encounterUUID, formSessionIntent);
+
+  const showPatientBanner = useMemo(() => {
+    return patient && workspaceLayout !== 'minimized' && mode !== 'embedded-view';
+  }, [patient, mode, workspaceLayout]);
 
   const showButtonSet = useMemo(() => {
     // if (mode === 'embedded-view') {
@@ -102,7 +104,7 @@ const FormEngine = ({
   }, []);
 
   return (
-    <Form noValidate ref={ref} className={classNames('cds--form', styles.form)} onSubmit={handleSubmit}>
+    <form ref={ref} noValidate className={classNames('cds--form', styles.form)} onSubmit={handleSubmit}>
       {isLoadingPatient || isLoadingFormJson ? (
         <Loader />
       ) : (
@@ -171,7 +173,7 @@ const FormEngine = ({
           </div>
         </FormFactoryProvider>
       )}
-    </Form>
+    </form>
   );
 };
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR addresses an issue with the patient banner not working as expected. The root cause was identified as the `<Form>` component from the Carbon Design System, which does not support ref forwarding. This caused the ref to remain null.

## Screenshots
<!-- Required if you are making UI changes. -->
![2024-08-09 14-16-17 2024-08-09 14_17_23](https://github.com/user-attachments/assets/50631e24-6fa6-447e-b858-699b1c7682f6)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-3740

## Other
<!-- Anything not covered above -->
