### PR TITLE
(fix) Add hide expression condition for number fields

### DIFF
--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -80,60 +80,58 @@ const DateField: React.FC<FormFieldInputProps> = ({ field, value: dateValue, err
     />
   ) : (
     !field.isHidden && (
-      <>
-        <div className={styles.datetime}>
-          {(field.datePickerFormat === 'calendar' || field.datePickerFormat === 'both') && (
-            <div className={styles.datePickerSpacing}>
-              <Layer>
-                <OpenmrsDatePicker
-                  id={field.id}
-                  onChange={onDateChange}
-                  labelText={
-                    <span className={styles.datePickerLabel}>
-                      <FieldLabel field={field} />
-                    </span>
-                  }
-                  isDisabled={field.isDisabled}
-                  isReadOnly={isTrue(field.readonly)}
-                  isRequired={field.isRequired ?? false}
-                  isInvalid={errors.length > 0}
-                  invalidText={errors[0]?.message}
-                  value={dateValue}
-                />
-              </Layer>
-              {warnings.length > 0 ? <div className={styles.datePickerWarn}>{warnings[0]?.message}</div> : null}
-            </div>
-          )}
+      <div className={styles.datetime}>
+        {(field.datePickerFormat === 'calendar' || field.datePickerFormat === 'both') && (
+          <div className={styles.datePickerSpacing}>
+            <Layer>
+              <OpenmrsDatePicker
+                id={field.id}
+                onChange={onDateChange}
+                labelText={
+                  <span className={styles.datePickerLabel}>
+                    <FieldLabel field={field} />
+                  </span>
+                }
+                isDisabled={field.isDisabled}
+                isReadOnly={isTrue(field.readonly)}
+                isRequired={field.isRequired ?? false}
+                isInvalid={errors.length > 0}
+                invalidText={errors[0]?.message}
+                value={dateValue}
+              />
+            </Layer>
+            {warnings.length > 0 ? <div className={styles.datePickerWarn}>{warnings[0]?.message}</div> : null}
+          </div>
+        )}
 
-          {field.datePickerFormat === 'both' || field.datePickerFormat === 'timer' ? (
-            <div>
-              <Layer>
-                <TimePicker
-                  className={classNames(styles.boldedLabel, styles.timeInput)}
-                  id={field.id}
-                  labelText={timePickerLabel}
-                  placeholder="HH:MM"
-                  pattern="(1[012]|[1-9]):[0-5][0-9])$"
-                  type="time"
-                  disabled={field.datePickerFormat === 'timer' ? field.isDisabled : !dateValue ? true : false}
-                  invalid={errors.length > 0}
-                  invalidText={errors[0]?.message}
-                  warning={warnings.length > 0}
-                  warningText={warnings[0]?.message}
-                  value={
-                    time
-                      ? time
-                      : dateValue instanceof Date
-                      ? dateValue.toLocaleDateString(window.navigator.language)
-                      : dateValue
-                  }
-                  onChange={onTimeChange}
-                />
-              </Layer>
-            </div>
-          ) : null}
-        </div>
-      </>
+        {field.datePickerFormat === 'both' || field.datePickerFormat === 'timer' ? (
+          <div>
+            <Layer>
+              <TimePicker
+                className={classNames(styles.boldedLabel, styles.timeInput)}
+                id={field.id}
+                labelText={timePickerLabel}
+                placeholder="HH:MM"
+                pattern="(1[012]|[1-9]):[0-5][0-9])$"
+                type="time"
+                disabled={field.datePickerFormat === 'timer' ? field.isDisabled : !dateValue ? true : false}
+                invalid={errors.length > 0}
+                invalidText={errors[0]?.message}
+                warning={warnings.length > 0}
+                warningText={warnings[0]?.message}
+                value={
+                  time
+                    ? time
+                    : dateValue instanceof Date
+                    ? dateValue.toLocaleDateString(window.navigator.language)
+                    : dateValue
+                }
+                onChange={onTimeChange}
+              />
+            </Layer>
+          </div>
+        ) : null}
+      </div>
     )
   );
 };

--- a/src/components/inputs/number/number.component.tsx
+++ b/src/components/inputs/number/number.component.tsx
@@ -44,30 +44,32 @@ const NumberField: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
       />
     </div>
   ) : (
-    <Layer>
-      <NumberInput
-        id={field.id}
-        invalid={errors.length > 0}
-        invalidText={errors[0]?.message}
-        label={<FieldLabel field={field} />}
-        max={Number(field.questionOptions.max) || undefined}
-        min={Number(field.questionOptions.min) || undefined}
-        name={field.id}
-        value={field.value ?? ''}
-        onChange={handleChange}
-        onBlur={onBlur}
-        allowEmpty={true}
-        size="lg"
-        hideSteppers={true}
-        onWheel={(e) => e.target.blur()}
-        disabled={field.isDisabled}
-        readOnly={field.readonly}
-        className={classNames(styles.controlWidthConstrained, styles.boldedLabel)}
-        warn={warnings.length > 0}
-        warnText={warnings[0]?.message}
-        step={0.01}
-      />
-    </Layer>
+    !field.isHidden && (
+      <Layer>
+        <NumberInput
+          id={field.id}
+          invalid={errors.length > 0}
+          invalidText={errors[0]?.message}
+          label={<FieldLabel field={field} />}
+          max={Number(field.questionOptions.max) || undefined}
+          min={Number(field.questionOptions.min) || undefined}
+          name={field.id}
+          value={field.value ?? ''}
+          onChange={handleChange}
+          onBlur={onBlur}
+          allowEmpty={true}
+          size="lg"
+          hideSteppers={true}
+          onWheel={(e) => e.target.blur()}
+          disabled={field.isDisabled}
+          readOnly={field.readonly}
+          className={classNames(styles.controlWidthConstrained, styles.boldedLabel)}
+          warn={warnings.length > 0}
+          warnText={warnings[0]?.message}
+          step={0.01}
+        />
+      </Layer>
+    )
   );
 };
 

--- a/src/components/inputs/text/text.component.tsx
+++ b/src/components/inputs/text/text.component.tsx
@@ -37,27 +37,25 @@ const TextField: React.FC<FormFieldInputProps> = ({ field, value, errors, warnin
     />
   ) : (
     !field.isHidden && (
-      <>
-        <div className={styles.boldedLabel}>
-          <Layer>
-            <TextInput
-              id={field.id}
-              labelText={<FieldLabel field={field} />}
-              onChange={setFieldValue}
-              onBlur={onBlur}
-              name={field.id}
-              value={value}
-              disabled={field.isDisabled}
-              readOnly={isTrue(field.readonly)}
-              invalid={errors.length > 0}
-              invalidText={errors[0]?.message}
-              warn={warnings.length > 0}
-              warnText={warnings.length && warnings[0].message}
-              maxLength={field.questionOptions.max || TextInput.maxLength}
-            />
-          </Layer>
-        </div>
-      </>
+      <div className={styles.boldedLabel}>
+        <Layer>
+          <TextInput
+            id={field.id}
+            labelText={<FieldLabel field={field} />}
+            onChange={setFieldValue}
+            onBlur={onBlur}
+            name={field.id}
+            value={value}
+            disabled={field.isDisabled}
+            readOnly={isTrue(field.readonly)}
+            invalid={errors.length > 0}
+            invalidText={errors[0]?.message}
+            warn={warnings.length > 0}
+            warnText={warnings.length > 0 ? warnings[0].message : undefined}
+            maxLength={field.questionOptions.max || TextInput.maxLength}
+          />
+        </Layer>
+      </div>
     )
   );
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This adds condition to hide number input if the hide expression is true. Currently the hideExpression doesn't work for number fields and those fields are always rendered. This fixes that. 

## Screenshots
**Before**
Number fields are always rendered regardless of expression logic
<img width="1702" alt="Screenshot 2024-09-03 at 14 04 29" src="https://github.com/user-attachments/assets/e73cc16a-450e-40c1-a7b6-ddd4841b3ae3">

**Expected Behavior**
Number fields with hide expression logic should be hidden by default and only visible when expression condition is true
<img width="1696" alt="Screenshot 2024-09-03 at 14 07 13" src="https://github.com/user-attachments/assets/e5487d94-8d40-484c-9222-4d473a778bb2">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
