### PR TITLE
(feat): O3-3855- Ability to clear dropdown input

### DIFF
--- a/src/components/inputs/select/dropdown.component.tsx
+++ b/src/components/inputs/select/dropdown.component.tsx
@@ -16,18 +16,16 @@ const Dropdown: React.FC<FormFieldInputProps> = ({ field, value, errors, warning
 
   const handleChange = useCallback(
     (selectedItem) => {
-      setFieldValue(selectedItem.value === '' ? null : selectedItem.value);
+      setFieldValue(selectedItem ? selectedItem.value || selectedItem.concept : null);
     },
     [setFieldValue],
   );
 
   const itemToString = useCallback(
     (item) => {
-      if (!item) return t('selectAnOption', 'Select an option');
-      const answer = field.questionOptions.answers.find((opt) => (opt.value ? opt.value == item : opt.concept == item));
-      return answer?.label;
+      return item ? item.label : '';
     },
-    [field.questionOptions.answers, t],
+    [t],
   );
 
   const isInline = useMemo(() => {
@@ -47,20 +45,20 @@ const Dropdown: React.FC<FormFieldInputProps> = ({ field, value, errors, warning
   ) : (
     !field.isHidden && (
       <div className={styles.boldedLabel}>
-  
         <Layer>
           <DropdownInput
             id={field.id}
             titleText={<FieldLabel field={field} />}
             label={t('chooseAnOption', 'Choose an option')}
-            items={[
-              { value: '', label: t('selectAnOption', 'Select an option') },
-              ...field.questionOptions.answers
-                .filter((answer) => !answer.isHidden)
-                .map((item) => ({ value: item.value || item.concept, label: item.label })),
-            ]}
-            itemToString={(item) => item.label}
-            selectedItem={value ? { value, label: itemToString(value) } : null}
+            items={field.questionOptions.answers
+              .filter((answer) => !answer.isHidden)
+              .map((item) => ({ value: item.value || item.concept, label: item.label }))}
+            itemToString={itemToString}
+            selectedItem={
+              value
+                ? field.questionOptions.answers.find((item) => (item.value || item.concept) === value)
+                : null
+            }
             onChange={({ selectedItem }) => handleChange(selectedItem)}
             disabled={field.isDisabled}
             readOnly={field.readonly}

--- a/src/components/inputs/select/dropdown.component.tsx
+++ b/src/components/inputs/select/dropdown.component.tsx
@@ -15,18 +15,19 @@ const Dropdown: React.FC<FormFieldInputProps> = ({ field, value, errors, warning
   const { layoutType, sessionMode, workspaceLayout, formFieldAdapters } = useFormProviderContext();
 
   const handleChange = useCallback(
-    (value) => {
-      setFieldValue(value);
+    (selectedItem) => {
+      setFieldValue(selectedItem.value === '' ? null : selectedItem.value);
     },
     [setFieldValue],
   );
 
   const itemToString = useCallback(
     (item) => {
+      if (!item) return t('selectAnOption', 'Select an option');
       const answer = field.questionOptions.answers.find((opt) => (opt.value ? opt.value == item : opt.concept == item));
       return answer?.label;
     },
-    [field.questionOptions.answers],
+    [field.questionOptions.answers, t],
   );
 
   const isInline = useMemo(() => {
@@ -46,16 +47,20 @@ const Dropdown: React.FC<FormFieldInputProps> = ({ field, value, errors, warning
   ) : (
     !field.isHidden && (
       <div className={styles.boldedLabel}>
+  
         <Layer>
           <DropdownInput
             id={field.id}
             titleText={<FieldLabel field={field} />}
             label={t('chooseAnOption', 'Choose an option')}
-            items={field.questionOptions.answers
-              .filter((answer) => !answer.isHidden)
-              .map((item) => item.value || item.concept)}
-            itemToString={itemToString}
-            selectedItem={value}
+            items={[
+              { value: '', label: t('selectAnOption', 'Select an option') },
+              ...field.questionOptions.answers
+                .filter((answer) => !answer.isHidden)
+                .map((item) => ({ value: item.value || item.concept, label: item.label })),
+            ]}
+            itemToString={(item) => item.label}
+            selectedItem={value ? { value, label: itemToString(value) } : null}
             onChange={({ selectedItem }) => handleChange(selectedItem)}
             disabled={field.isDisabled}
             readOnly={field.readonly}

--- a/src/components/inputs/select/dropdown.test.tsx
+++ b/src/components/inputs/select/dropdown.test.tsx
@@ -117,4 +117,41 @@ describe.skip('dropdown input field', () => {
       });
     });
   });
+
+  it('should clear selection when empty option is selected', async () => {
+    // setup
+    question.meta.previousValue = {
+      uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
+      person: '833db896-c1f0-11eb-8529-0242ac130003',
+      obsDatetime: encounterContext.encounterDate,
+      concept: '1c43b05b-b6d8-4eb5-8f37-0b14f5347568',
+      location: { uuid: '41e6e516-c1f0-11eb-8529-0242ac130003' },
+      order: null,
+      groupMembers: [],
+      voided: false,
+      value: '6ddd933a-e65c-4f35-8884-c555b50c55e1',
+    };
+    await renderForm({ 'patient-past-program': question.meta.previousValue.value });
+    const dropdownWidget = screen.getByRole('combobox', { name: /Patient past program./ });
+
+    // select an option first
+    fireEvent.click(dropdownWidget);
+    const oncologyScreeningOption = screen.getByText('Oncology Screening and Diagnosis Program');
+    fireEvent.click(oncologyScreeningOption);
+
+    // clear the selection
+    fireEvent.click(dropdownWidget);
+    const clearOption = screen.getByText('Select an option');
+    fireEvent.click(clearOption);
+
+    // verify
+    await act(async () => {
+      expect(question.meta.submission.newValue).toEqual({
+        uuid: '305ed1fc-c1fd-11eb-8529-0242ac130003',
+        value: null,
+        formFieldNamespace: 'rfe-forms',
+        formFieldPath: 'rfe-forms-patient-past-program',
+      });
+    });
+  });
 });

--- a/src/transformers/default-schema-transformer.ts
+++ b/src/transformers/default-schema-transformer.ts
@@ -161,6 +161,16 @@ function transformByRendering(question: FormField) {
     case 'markdown':
       question.type = 'control';
       break;
+    case 'select':
+    case 'dropdown':
+      if (!question.questionOptions.answers.some((answer) => answer.value === '')) {
+        question.questionOptions.answers.unshift({
+          value: '',
+          label: 'Select an option',
+          isDefaultOption: true,
+        });
+      }
+      break;
   }
   return question;
 }


### PR DESCRIPTION
## Summary
It is possible to clear a selected dropdown option in the form using the approach where we have the first selectable option as “empty”.

## Screenshots
<img width="1418" alt="Screenshot 2024-09-04 at 11 50 52" src="https://github.com/user-attachments/assets/0e2136f7-c545-4f36-a4f8-1ca22de2741c">
<img width="1424" alt="Screenshot 2024-09-04 at 11 50 30" src="https://github.com/user-attachments/assets/f3d87322-9448-4f74-92b1-06a1f07e3c2c">
<img width="1429" alt="Screenshot 2024-09-04 at 11 50 23" src="https://github.com/user-attachments/assets/4d365f98-83e1-4689-b680-9242a911ae18">


## Related Issue
https://openmrs.atlassian.net/browse/O3-3855


