### PR TITLE
(fix) Reactively cascade form field update event

### DIFF
--- a/src/components/group/obs-group.component.tsx
+++ b/src/components/group/obs-group.component.tsx
@@ -16,7 +16,7 @@ export const ObsGroup: React.FC<FormFieldInputProps> = ({ field }) => {
         return (
           <div className={classNames(styles.flexColumn)} key={keyId}>
             <div className={styles.groupContainer}>
-              <FormFieldRenderer field={child} valueAdapter={formFieldAdapters[child.type]} />
+              <FormFieldRenderer fieldId={child.id} valueAdapter={formFieldAdapters[child.type]} />
             </div>
           </div>
         );

--- a/src/components/inputs/select/dropdown.component.tsx
+++ b/src/components/inputs/select/dropdown.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useEffect } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Dropdown as DropdownInput, Layer } from '@carbon/react';
 import { shouldUseInlineLayout } from '../../../utils/form-helper';

--- a/src/components/inputs/select/dropdown.component.tsx
+++ b/src/components/inputs/select/dropdown.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Dropdown as DropdownInput, Layer } from '@carbon/react';
 import { shouldUseInlineLayout } from '../../../utils/form-helper';

--- a/src/components/renderer/field/form-field-renderer.component.tsx
+++ b/src/components/renderer/field/form-field-renderer.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   type FormField,
   type RenderType,
@@ -24,14 +24,14 @@ import { getFieldControlWithFallback } from '../../../utils/form-helper';
 import { handleFieldLogic } from './fieldLogic';
 
 export interface FormFieldRendererProps {
-  field: FormField;
+  fieldId: string;
   valueAdapter: FormFieldValueAdapter;
   repeatOptions?: {
     targetRendering: RenderType;
   };
 }
 
-export const FormFieldRenderer = ({ field, valueAdapter, repeatOptions }: FormFieldRendererProps) => {
+export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: FormFieldRendererProps) => {
   const [inputComponentWrapper, setInputComponentWrapper] = useState<{
     value: React.ComponentType<FormFieldInputProps>;
   }>(null);
@@ -50,8 +50,10 @@ export const FormFieldRenderer = ({ field, valueAdapter, repeatOptions }: FormFi
     removeInvalidField,
   } = context;
 
-  const fieldValue = useWatch({ control, name: field.id, exact: true });
+  const fieldValue = useWatch({ control, name: fieldId, exact: true });
   const noop = () => {};
+
+  const field = useMemo(() => formFields.find((field) => field.id === fieldId), [fieldId, formFields]);
 
   useEffect(() => {
     if (hasRendering(field, 'repeating') && repeatOptions?.targetRendering) {

--- a/src/components/renderer/section/section-renderer.component.tsx
+++ b/src/components/renderer/section/section-renderer.component.tsx
@@ -12,7 +12,11 @@ export const SectionRenderer = ({ section }: { section: FormSection }) => {
       {section.questions.map((question) =>
         formFieldAdapters[question.type] ? (
           <div key={`${sectionId}-${question.id}`} className={styles.sectionBody}>
-            <FormFieldRenderer key={question.id} field={question} valueAdapter={formFieldAdapters[question.type]} />
+            <FormFieldRenderer
+              key={question.id}
+              fieldId={question.id}
+              valueAdapter={formFieldAdapters[question.type]}
+            />
           </div>
         ) : null,
       )}

--- a/src/components/repeat/repeat.component.tsx
+++ b/src/components/repeat/repeat.component.tsx
@@ -129,7 +129,7 @@ const Repeat: React.FC<FormFieldInputProps> = ({ field }) => {
     return rows.map((field, index) => {
       const component = (
         <FormFieldRenderer
-          field={field}
+          fieldId={field.id}
           valueAdapter={formFieldAdapters[field.type]}
           repeatOptions={{ targetRendering: getQuestionWithSupportedRendering(field).questionOptions.rendering }}
         />

--- a/src/hooks/useFormStateHelpers.ts
+++ b/src/hooks/useFormStateHelpers.ts
@@ -7,7 +7,7 @@ export function useFormStateHelpers(dispatch: Dispatch<Action>, formFields: Form
     dispatch({ type: 'ADD_FORM_FIELD', value: field });
   }, []);
   const updateFormField = useCallback((field: FormField) => {
-    dispatch({ type: 'UPDATE_FORM_FIELD', value: field });
+    dispatch({ type: 'UPDATE_FORM_FIELD', value: structuredClone(field) });
   }, []);
 
   const getFormField = useCallback(


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

**Background:** In the form-engine, state management is typically handled using a reducer pattern, often in conjunction with React's useReducer hook. This is propped with helpers to conveniently update the state eg. [updateFormField](https://github.com/openmrs/openmrs-esm-form-engine-lib/blob/main/src/hooks/useFormStateHelpers.ts#L9-L11). 

**Issue:** The form-renderer currently [receives the field object directly from the section](https://github.com/openmrs/openmrs-esm-form-engine-lib/blob/main/src/components/renderer/section/section-renderer.component.tsx#L15) instead of the reactive flattened form fields state. This obscures the cascade of the reactive events.

**Solution**: Treat the flattened `formFields` state as the source of truth.

## Screenshots
<!-- Required if you are making UI changes. -->
N/A

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

https://openmrs.atlassian.net/browse/O3-3908

## Other
<!-- Anything not covered above -->
