### PR TITLE
(fix) Add hide expression condition for workplace-launcher

### DIFF
--- a/src/components/inputs/workspace-launcher/workspace-launcher.component.tsx
+++ b/src/components/inputs/workspace-launcher/workspace-launcher.component.tsx
@@ -23,12 +23,14 @@ const WorkspaceLauncher: React.FC<FormFieldInputProps> = ({ field }) => {
   };
 
   return (
-    <div>
-      <div className={styles.label}>{t(field.label)}</div>
-      <div className={styles.workspaceButton}>
-        <Button onClick={handleLaunchWorkspace}>{field.questionOptions?.buttonLabel ?? t('launchWorkspace')}</Button>
+    !field.isHidden && (
+      <div>
+        <div className={styles.label}>{t(field.label)}</div>
+        <div className={styles.workspaceButton}>
+          <Button onClick={handleLaunchWorkspace}>{field.questionOptions?.buttonLabel ?? t('launchWorkspace')}</Button>
+        </div>
       </div>
-    </div>
+    )
   );
 };
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This adds condition to hide the workplace launcher button if the hide expression is true. Currently the hideExpression doesn't work for workplace launcher fields. This fixes that.


## Screenshots
<!-- Required if you are making UI changes. -->
### Initial Behaviour 
<img width="1727" alt="Screenshot 2024-09-06 at 09 50 16" src="https://github.com/user-attachments/assets/9dbbf6a8-28e2-40d2-aefd-c968a129d9a2">


### Epected Behaviour 

https://github.com/user-attachments/assets/32b05ca6-8730-41fd-b608-c2726397f6d2



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-3910

## Other
<!-- Anything not covered above -->
