### PR TITLE
(fix) Resolve issue with loading previous values

### DIFF
--- a/src/adapters/obs-adapter.test.ts
+++ b/src/adapters/obs-adapter.test.ts
@@ -757,9 +757,29 @@ describe('ObsAdapter - getDisplayValue', () => {
       },
       id: 'hts-date',
     };
+
     const dateValue = new Date('2016-11-19T00:00');
     const displayValue = ObsAdapter.getDisplayValue(field, dateValue);
+
     expect(displayValue).toBe('19-Nov-2016');
+  });
+
+  it('should return the display value for a datetime', () => {
+    const field: FormField = {
+      label: 'HTS Date',
+      type: 'obs',
+      datePickerFormat: 'both',
+      questionOptions: {
+        rendering: 'date',
+        concept: 'j8b6705b-b6d8-4eju-8f37-0b14f5347569',
+      },
+      id: 'hts-date',
+    };
+
+    const dateValue = new Date('2016-11-19T11:35');
+    const displayValue = ObsAdapter.getDisplayValue(field, dateValue);
+
+    expect(displayValue).toBe('19-Nov-2016, 11:35 AM');
   });
 });
 

--- a/src/adapters/obs-adapter.test.ts
+++ b/src/adapters/obs-adapter.test.ts
@@ -745,6 +745,24 @@ describe('ObsAdapter - getInitialValue', () => {
   });
 });
 
+describe('ObsAdapter - getDisplayValue', () => {
+  it('should return the display value for a date', () => {
+    const field: FormField = {
+      label: 'HTS Date',
+      type: 'obs',
+      datePickerFormat: 'calendar',
+      questionOptions: {
+        rendering: 'date',
+        concept: 'j8b6705b-b6d8-4eju-8f37-0b14f5347569',
+      },
+      id: 'hts-date',
+    };
+    const dateValue = new Date('2016-11-19T00:00');
+    const displayValue = ObsAdapter.getDisplayValue(field, dateValue);
+    expect(displayValue).toBe('19-Nov-2016');
+  });
+});
+
 describe('hasPreviousObsValueChanged', () => {
   it('should support coded values', () => {
     const codedField = {

--- a/src/adapters/obs-adapter.ts
+++ b/src/adapters/obs-adapter.ts
@@ -14,6 +14,7 @@ import {
   clearSubmission,
   flattenObsList,
   parseToLocalDateTime,
+  formatDateAsDisplayString,
 } from '../utils/common-utils';
 import { type FormContextProps } from '../provider/form-provider';
 import { type FormFieldValueAdapter } from '../types';
@@ -58,6 +59,9 @@ export const ObsAdapter: FormFieldValueAdapter = {
     const rendering = field.questionOptions.rendering;
     if (isEmpty(value)) {
       return value;
+    }
+    if (value instanceof Date) {
+      return formatDateAsDisplayString(field, value);
     }
     if (rendering == 'checkbox') {
       return value.map(

--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -8,9 +8,10 @@ import { shouldUseInlineLayout } from '../../../utils/form-helper';
 import { isEmpty } from '../../../validators/form-validator';
 import FieldValueView from '../../value/view/field-value-view.component';
 import styles from './date.scss';
-import { OpenmrsDatePicker, formatDate, formatTime } from '@openmrs/esm-framework';
+import { OpenmrsDatePicker } from '@openmrs/esm-framework';
 import { useFormProviderContext } from '../../../provider/form-provider';
 import FieldLabel from '../../field-label/field-label.component';
+import { formatDateAsDisplayString } from '../../../utils/common-utils';
 
 const DateField: React.FC<FormFieldInputProps> = ({ field, value: dateValue, errors, warnings, setFieldValue }) => {
   const { t } = useTranslation();
@@ -74,7 +75,7 @@ const DateField: React.FC<FormFieldInputProps> = ({ field, value: dateValue, err
   return sessionMode == 'view' || sessionMode == 'embedded-view' ? (
     <FieldValueView
       label={t(field.label)}
-      value={dateValue instanceof Date ? getDisplay(dateValue, field.datePickerFormat) : dateValue}
+      value={dateValue instanceof Date ? formatDateAsDisplayString(field, dateValue) : dateValue}
       conceptName={field.meta?.concept?.display}
       isInline={isInline}
     />
@@ -135,13 +136,5 @@ const DateField: React.FC<FormFieldInputProps> = ({ field, value: dateValue, err
     )
   );
 };
-
-function getDisplay(date: Date, rendering: string) {
-  const dateString = formatDate(date);
-  if (rendering == 'both') {
-    return `${dateString} ${formatTime(date)}`;
-  }
-  return dateString;
-}
 
 export default DateField;

--- a/src/form-engine.component.tsx
+++ b/src/form-engine.component.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { FormField, FormSchema, SessionMode } from './types';
 import { useSession, type Visit } from '@openmrs/esm-framework';
-import { useFormJson } from '.';
+import { isEmpty, useFormJson } from '.';
 import FormProcessorFactory from './components/processor-factory/form-processor-factory.component';
 import Loader from './components/loaders/loader.component';
 import { usePatientData } from './hooks/usePatientData';
@@ -62,6 +62,7 @@ const FormEngine = ({
   const [showSidebar, setShowSidebar] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isFormDirty, setIsFormDirty] = useState(false);
+  const sessionMode = !isEmpty(mode) ? mode : !isEmpty(encounterUUID) ? 'edit' : 'enter';
   // TODO: Updating this prop triggers a rerender of the entire form. This means whenever we scroll into a new page, the form is rerendered.
   // Figure out a way to avoid this. Maybe use a ref with an observer instead of a state?
   const [currentPage, setCurrentPage] = useState('');
@@ -110,7 +111,7 @@ const FormEngine = ({
       ) : (
         <FormFactoryProvider
           patient={patient}
-          sessionMode={mode}
+          sessionMode={sessionMode}
           sessionDate={sessionDate}
           formJson={refinedFormJson}
           workspaceLayout={workspaceLayout}

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import { type FormField, type OpenmrsObs, type RenderType } from '../types';
 import { isEmpty } from '../validators/form-validator';
+import { formatDate, formatTime } from '@openmrs/esm-framework';
 
 export function flattenObsList(obsList: OpenmrsObs[]): OpenmrsObs[] {
   const flattenedList: OpenmrsObs[] = [];
@@ -64,4 +65,12 @@ export function parseToLocalDateTime(dateString: string): Date {
     console.error(e);
   }
   return dateObj;
+}
+
+export function formatDateAsDisplayString(field: FormField, date: Date) {
+  const dateString = formatDate(date);
+  if (field.datePickerFormat == 'both') {
+    return `${dateString} ${formatTime(date)}`;
+  }
+  return dateString;
 }

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { type FormField, type OpenmrsObs, type RenderType } from '../types';
 import { isEmpty } from '../validators/form-validator';
-import { formatDate, formatTime } from '@openmrs/esm-framework';
+import { formatDate, type FormatDateOptions } from '@openmrs/esm-framework';
 
 export function flattenObsList(obsList: OpenmrsObs[]): OpenmrsObs[] {
   const flattenedList: OpenmrsObs[] = [];
@@ -68,9 +68,11 @@ export function parseToLocalDateTime(dateString: string): Date {
 }
 
 export function formatDateAsDisplayString(field: FormField, date: Date) {
-  const dateString = formatDate(date);
-  if (field.datePickerFormat == 'both') {
-    return `${dateString} ${formatTime(date)}`;
+  const options: Partial<FormatDateOptions> = { noToday: true };
+  if (field.datePickerFormat === 'calendar') {
+    options.time = false;
+  } else {
+    options.time = true;
   }
-  return dateString;
+  return formatDate(date, options);
 }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
For some reason the workspace no longer provides the "session mode" details to the root component. As result, we end up with an `undefined` "session mode" value which causes side effects like the "use previous value" feature not working. This PR ensures we infer the session mode in such scenarios. It the obs adapter to ensure that we properly format the date object to a display string.

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="440" alt="Screenshot 2024-09-12 at 16 50 14" src="https://github.com/user-attachments/assets/3beb5d7b-4ef7-45c8-9b4e-82e0aec0c55d">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-3918

## Other
<!-- Anything not covered above -->
