### PR TITLE
(chore) Move getFieldControlWithFallback to registry 

### DIFF
--- a/src/components/renderer/field/form-field-renderer.component.tsx
+++ b/src/components/renderer/field/form-field-renderer.component.tsx
@@ -16,11 +16,10 @@ import { hasRendering } from '../../../utils/common-utils';
 import { useFormProviderContext } from '../../../provider/form-provider';
 import { isEmpty } from '../../../validators/form-validator';
 import PreviousValueReview from '../../previous-value-review/previous-value-review.component';
-import { getRegisteredControl } from '../../../registry/registry';
+import { getFieldControlWithFallback, getRegisteredControl } from '../../../registry/registry';
 import styles from './form-field-renderer.scss';
 import { isTrue } from '../../../utils/boolean-utils';
 import UnspecifiedField from '../../inputs/unspecified/unspecified.component';
-import { getFieldControlWithFallback } from '../../../utils/form-helper';
 import { handleFieldLogic } from './fieldLogic';
 
 export interface FormFieldRendererProps {

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -122,7 +122,7 @@ export async function getRegisteredControl(renderType: string) {
   let component = inbuiltControls.find(
     (control) => control.name === renderType || control?.alias === renderType,
   )?.component;
-  // if undefined, try serching through the registered custom controls
+  // if undefined, try searching through the registered custom controls
   if (!component) {
     const importedControl = await getFormsStore()
       .controls.find((control) => control.name === renderType || control?.alias === renderType)

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -1,4 +1,5 @@
 import {
+  type FormField,
   type DataSource,
   type FormFieldValidator,
   type FormSchemaTransformer,
@@ -132,6 +133,26 @@ export async function getRegisteredControl(renderType: string) {
   return component;
 }
 
+/**
+ * Retrieves the appropriate field control for a question, considering missing concepts.
+ * If the question is of type 'obs' and has a missing concept, it falls back to a disabled text input.
+ * Otherwise, it retrieves the registered control based on the rendering specified in the question.
+ * @param question - The FormField representing the question.
+ * @returns The field control to be used for rendering the question.
+ */
+export function getFieldControlWithFallback(question: FormField) {
+  // Check if the question has a missing concept
+  if (hasMissingConcept(question)) {
+    // If so, render a disabled text input
+    question.disabled = true;
+    question.isDisabled = true;
+    return getRegisteredControl('text');
+  }
+
+  // Retrieve the registered control based on the specified rendering
+  return getRegisteredControl(question.questionOptions.rendering);
+}
+
 export async function getRegisteredFieldValueAdapter(type: string): Promise<FormFieldValueAdapter> {
   if (registryCache.fieldValueAdapters[type]) {
     return registryCache.fieldValueAdapters[type];
@@ -258,4 +279,10 @@ function getFormsStore(): FormsRegistryStoreState {
     dataSources: [],
     formSchemaTransformers: [],
   }).getState();
+}
+
+function hasMissingConcept(question: FormField) {
+  return (
+    question.type == 'obs' && !question.questionOptions.concept && question.questionOptions.rendering !== 'fixed-value'
+  );
 }

--- a/src/utils/form-helper.ts
+++ b/src/utils/form-helper.ts
@@ -158,32 +158,6 @@ export function findConceptByReference(reference: string, concepts) {
   }
 }
 
-/**
- * Retrieves the appropriate field control for a question, considering missing concepts.
- * If the question is of type 'obs' and has a missing concept, it falls back to a disabled text input.
- * Otherwise, it retrieves the registered control based on the rendering specified in the question.
- * @param question - The FormField representing the question.
- * @returns The field control to be used for rendering the question.
- */
-export function getFieldControlWithFallback(question: FormField) {
-  // Check if the question has a missing concept
-  if (hasMissingConcept(question)) {
-    // If so, render a disabled text input
-    question.disabled = true;
-    question.isDisabled = true;
-    return getRegisteredControl('text');
-  }
-
-  // Retrieve the registered control based on the specified rendering
-  return getRegisteredControl(question.questionOptions.rendering);
-}
-
-export function hasMissingConcept(question: FormField) {
-  return (
-    question.type == 'obs' && !question.questionOptions.concept && question.questionOptions.rendering !== 'fixed-value'
-  );
-}
-
 export function scrollIntoView(viewId: string, shouldFocus: boolean = false) {
   const currentElement = document.getElementById(viewId);
   currentElement?.scrollIntoView({


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Moving the getFieldControlWithFallback(..) function to the registry resolves most of the issues related to cyclic refs.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
