### PR TITLE
O3 3685: Enable Deleting or Clearing Files in File Picker Component in Edit Mode

### DIFF
--- a/src/components/inputs/file/file.component.tsx
+++ b/src/components/inputs/file/file.component.tsx
@@ -3,7 +3,7 @@ import { FileUploader, Button } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import { isTrue } from '../../../utils/boolean-utils';
 import Camera from './camera/camera.component';
-import { Close, DocumentPdf } from '@carbon/react/icons';
+import { Close, DocumentPdf, TrashCan } from '@carbon/react/icons';
 import styles from './file.scss';
 import { type FormFieldInputProps } from '../../../types';
 import { useFormProviderContext } from '../../../provider/form-provider';
@@ -49,6 +49,12 @@ const File: React.FC<FormFieldInputProps> = ({ field, value, setFieldValue }) =>
     },
     [setFieldValue],
   );
+
+  const handleDeleteFile = useCallback(() => {
+    setImagePreview(null);
+    setFieldValue(null);
+    setDataSource(null);
+  }, [setFieldValue]);
 
   if (isViewMode(sessionMode) && !value) {
     return (
@@ -99,6 +105,14 @@ const File: React.FC<FormFieldInputProps> = ({ field, value, setFieldValue }) =>
               <img src={value.src} alt="Preview" width="200px" />
             )}
           </div>
+          <Button
+            kind="danger"
+            renderIcon={TrashCan}
+            iconDescription={t('deleteFile', 'Delete file')}
+            onClick={handleDeleteFile}
+          >
+            {t('deleteFile', 'Delete file')}
+          </Button>
         </div>
       )}
       {dataSource === 'filePicker' && (

--- a/src/components/inputs/file/file.component.tsx
+++ b/src/components/inputs/file/file.component.tsx
@@ -49,12 +49,13 @@ const File: React.FC<FormFieldInputProps> = ({ field, value, setFieldValue }) =>
     },
     [setFieldValue],
   );
-
-  const handleDeleteFile = useCallback(() => {
-    setImagePreview(null);
+  const [clearedFiles, setClearedFiles] = useState([]);
+  const handleClearFile = (fileId) => {
+    setClearedFiles((prevClearedFiles) => [...prevClearedFiles, fileId]);
     setFieldValue(null);
+    setImagePreview(null);
     setDataSource(null);
-  }, [setFieldValue]);
+  };
 
   if (isViewMode(sessionMode) && !value) {
     return (
@@ -93,6 +94,13 @@ const File: React.FC<FormFieldInputProps> = ({ field, value, setFieldValue }) =>
             {t('cameraCapture', 'Camera capture')}
           </Button>
         </div>
+        {value && (
+          <div className={`${styles.selectorButton} ${styles.clearFileButton}`}>
+            <Button kind="danger" onClick={handleClearFile} renderIcon={TrashCan}>
+              {t('clearFile', 'Clear file')}
+            </Button>
+          </div>
+        )}
       </div>
       {!dataSource && value && (
         <div className={styles.editModeImage}>
@@ -105,14 +113,6 @@ const File: React.FC<FormFieldInputProps> = ({ field, value, setFieldValue }) =>
               <img src={value.src} alt="Preview" width="200px" />
             )}
           </div>
-          <Button
-            kind="danger"
-            renderIcon={TrashCan}
-            iconDescription={t('deleteFile', 'Delete file')}
-            onClick={handleDeleteFile}
-          >
-            {t('deleteFile', 'Delete file')}
-          </Button>
         </div>
       )}
       {dataSource === 'filePicker' && (

--- a/src/components/inputs/file/file.component.tsx
+++ b/src/components/inputs/file/file.component.tsx
@@ -33,29 +33,48 @@ const File: React.FC<FormFieldInputProps> = ({ field, value, setFieldValue }) =>
 
   const handleFilePickerChange = useCallback(
     (event) => {
-      // TODO: Add multiple file upload support; see: https://openmrs.atlassian.net/browse/O3-3682
       const [selectedFile]: File[] = Array.from(event.target.files);
       setImagePreview(null);
-      setFieldValue(selectedFile);
+      setFieldValue({
+        value: selectedFile,
+        meta: {
+          submission: {
+            newValue: {
+              value: selectedFile
+            }
+          }
+        }
+      });
     },
     [setFieldValue],
   );
-
+  
   const handleCameraImageChange = useCallback(
     (newImage) => {
       setImagePreview(newImage);
       setCameraWidgetVisible(false);
-      setFieldValue(newImage);
+      setFieldValue({
+        value: newImage,
+        meta: {
+          submission: {
+            newValue: {
+              value: newImage
+            }
+          }
+        }
+      });
     },
     [setFieldValue],
   );
-  const [clearedFiles, setClearedFiles] = useState([]);
-  const handleClearFile = (fileId) => {
-    setClearedFiles((prevClearedFiles) => [...prevClearedFiles, fileId]);
-    setFieldValue(null);
+
+  const handleClearFile = useCallback(() => {
+    setFieldValue({
+      action: 'CLEAR',
+      previousValue: value,
+    });
     setImagePreview(null);
     setDataSource(null);
-  };
+  }, [setFieldValue, null]);
 
   if (isViewMode(sessionMode) && !value) {
     return (
@@ -102,7 +121,7 @@ const File: React.FC<FormFieldInputProps> = ({ field, value, setFieldValue }) =>
           </div>
         )}
       </div>
-      {!dataSource && value && (
+      {!dataSource && value && value.action !== 'CLEAR' && (
         <div className={styles.editModeImage}>
           <div className={styles.imageContent}>
             {value.bytesContentFamily === 'PDF' ? (

--- a/src/components/inputs/file/file.scss
+++ b/src/components/inputs/file/file.scss
@@ -28,10 +28,30 @@
   display: flex;
   align-items: center;
   margin-bottom: 1rem;
+  flex-wrap: wrap;
 }
 
 .selectorButton {
   margin-right: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.clearFileButton {
+  display: flex;
+  align-items: center;
+
+  button {
+    background-color: #da1e28;
+    color: #ffffff;
+
+    &:hover {
+      background-color: #b81921;
+    }
+    svg {
+      fill: currentColor;
+      margin-left: 0.5rem;
+    }
+  }
 }
 
 .caption {

--- a/src/processors/encounter/encounter-processor-helper.ts
+++ b/src/processors/encounter/encounter-processor-helper.ts
@@ -218,8 +218,13 @@ function prepareObs(obsForSubmission: OpenmrsObs[], fields: FormField[]) {
         }
       }
       if (hasSubmission(field)) {
-        addObsToList(obsForSubmission, field.meta.submission.newValue);
-        addObsToList(obsForSubmission, field.meta.submission.voidedValue);
+        if (hasRendering(field, 'file') && field.meta.submission.newValue?.action === 'CLEAR') {
+          //void the existing obs
+          addObsToList(obsForSubmission, voidObs(field.meta.previousValue));
+        } else {
+          addObsToList(obsForSubmission, field.meta.submission.newValue);
+          addObsToList(obsForSubmission, field.meta.submission.voidedValue);
+        }
       }
     });
 }


### PR DESCRIPTION
## Requirements
Enable Deleting or Clearing Files in File Picker Component in Edit Mode

## Summary
When a file is selected using the file picker component and the form is later opened in edit mode, there is now an option to delete or clear the selected file. 

## Screenshots
<img width="1440" alt="Screenshot 2024-09-11 at 13 16 23" src="https://github.com/user-attachments/assets/c3458123-e143-48af-87ef-010edbca6f3b">
<img width="1440" alt="Screenshot 2024-09-11 at 13 16 31" src="https://github.com/user-attachments/assets/a125cd07-66d5-4ded-ab8b-9aeffdffeb03">

## Related Issue
https://openmrs.atlassian.net/browse/O3-3685