### PR TITLE
(Enhancement): O3-3685: Enable Deleting or Clearing Files in File Picker Component in Edit Mode

### DIFF
--- a/src/components/inputs/file/file.component.tsx
+++ b/src/components/inputs/file/file.component.tsx
@@ -106,7 +106,6 @@ const File: React.FC<FormFieldInputProps> = ({ field, value, setFieldValue }) =>
             {t('uploadImage', 'Upload image')}
           </Button>
         </div>
-
         <div className={styles.selectorButton}>
           <Button disabled={isTrue(field.readonly)} onClick={() => setDataSource('camera')}>
             {t('cameraCapture', 'Camera capture')}


### PR DESCRIPTION
## Requirements
When a file is selected using the file picker component and the form is later opened in edit mode, there is currently no option to delete or clear the selected file. 

## Summary
The user can now successfully edit an encounter and add or remove an image/file by clearing it.

## Screenshots
<img width="1440" alt="Screenshot 2024-09-16 at 11 15 59" src="https://github.com/user-attachments/assets/bad5ffbe-a9ec-4a9a-9c10-45249573e38a">
<img width="1440" alt="Screenshot 2024-09-16 at 11 15 49" src="https://github.com/user-attachments/assets/23aafbd3-11a3-4636-9516-dfb395c378d8">


## Related Issue
https://openmrs.atlassian.net/browse/O3-3685

## Other
the delete persists on form submission and reloading
