### PR TITLE
(fix) Throw error when queried form is not found

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -106,9 +106,13 @@ export async function fetchOpenMRSForm(nameOrUUID: string): Promise<OpenmrsForm 
     return openmrsFormResponse;
   }
 
-  return openmrsFormResponse.results?.length
-    ? openmrsFormResponse.results.find((form) => form.retired === false)
-    : new Error(`Form with ${nameOrUUID} was not found`);
+  if (openmrsFormResponse.results?.length) {
+    const form = openmrsFormResponse.results.find((form) => form.retired === false);
+    if (form) {
+      return form;
+    }
+  }
+  throw new Error(`Form with "${nameOrUUID}" was not found`);
 }
 
 /**
@@ -121,7 +125,7 @@ export async function fetchClobData(form: OpenmrsForm): Promise<any | null> {
     return null;
   }
 
-  const jsonSchemaResource = form.resources.find(({ name }) => name === 'JSON schema');
+  const jsonSchemaResource = form.resources?.find(({ name }) => name === 'JSON schema');
   if (!jsonSchemaResource) {
     return null;
   }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -112,7 +112,7 @@ export async function fetchOpenMRSForm(nameOrUUID: string): Promise<OpenmrsForm 
       return form;
     }
   }
-  throw new Error(`Form with "${nameOrUUID}" was not found`);
+  throw new Error(`Form with ID "${nameOrUUID}" was not found`);
 }
 
 /**

--- a/src/hooks/useFormJson.test.tsx
+++ b/src/hooks/useFormJson.test.tsx
@@ -169,7 +169,7 @@ describe('useFormJson', () => {
     // verify
     expect(hook.result.current.isLoading).toBe(false);
     expect(hook.result.current.formError.message).toBe(
-      'Error loading form JSON: Form with "non-existent-form" was not found',
+      'Error loading form JSON: Form with ID "non-existent-form" was not found',
     );
     expect(hook.result.current.formJson).toBe(null);
   });

--- a/src/hooks/useFormJson.tsx
+++ b/src/hooks/useFormJson.tsx
@@ -29,7 +29,7 @@ export function useFormJson(formUuid: string, rawFormJson: any, encounterUuid: s
 
   return {
     formJson,
-    isLoading: !formJson,
+    isLoading: !formJson && !error,
     formError: error,
   };
 }


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [X] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [X] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Enhances the form loader to throw an error that is then reported to user incase the queried form resource was not found.

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="424" alt="Screenshot 2024-09-23 at 16 46 10" src="https://github.com/user-attachments/assets/8dcc7b46-cb3e-40cf-be7d-5ef4bef934c2">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
N/A

## Other
<!-- Anything not covered above -->
