### PR TITLE
(fix) Propagate Form Context State Changes to the Form Factory Provider

### DIFF
--- a/src/components/processor-factory/form-processor-factory.component.tsx
+++ b/src/components/processor-factory/form-processor-factory.component.tsx
@@ -113,6 +113,7 @@ const FormProcessorFactory = ({
         <FormRenderer
           processorContext={processorContext}
           initialValues={initialValues}
+          isSubForm={isSubForm}
           setIsLoadingFormDependencies={setIsLoadingFormDependencies}
         />
       )}

--- a/src/components/renderer/form/form-renderer.component.tsx
+++ b/src/components/renderer/form/form-renderer.component.tsx
@@ -13,10 +13,16 @@ import { useFormStateHelpers } from '../../../hooks/useFormStateHelpers';
 export type FormRendererProps = {
   processorContext: FormProcessorContextProps;
   initialValues: Record<string, any>;
+  isSubForm: boolean;
   setIsLoadingFormDependencies: (isLoading: boolean) => void;
 };
 
-export const FormRenderer = ({ processorContext, initialValues, setIsLoadingFormDependencies }: FormRendererProps) => {
+export const FormRenderer = ({
+  processorContext,
+  initialValues,
+  isSubForm,
+  setIsLoadingFormDependencies,
+}: FormRendererProps) => {
   const { evaluatedFields, evaluatedFormJson } = useEvaluateFormFieldExpressions(initialValues, processorContext);
   const { registerForm, setIsFormDirty, workspaceLayout } = useFormFactory();
   const methods = useForm({
@@ -64,8 +70,8 @@ export const FormRenderer = ({ processorContext, initialValues, setIsLoadingForm
   }, [processorContext, workspaceLayout, methods, formFields, formJson, invalidFields]);
 
   useEffect(() => {
-    registerForm(formJson.name, context);
-  }, [formJson.name, context]);
+    registerForm(formJson.name, isSubForm, context);
+  }, [formJson.name, isSubForm, context]);
 
   useEffect(() => {
     setIsFormDirty(isDirty);
@@ -91,12 +97,7 @@ export const FormRenderer = ({ processorContext, initialValues, setIsLoadingForm
             />
           );
         }
-        return (
-          <PageRenderer
-            key={page.label}
-            page={page}
-          />
-        );
+        return <PageRenderer key={page.label} page={page} />;
       })}
     </FormProvider>
   );

--- a/src/form-engine.component.tsx
+++ b/src/form-engine.component.tsx
@@ -35,7 +35,6 @@ interface FormEngineProps {
 // TODOs:
 // - Implement sidebar
 // - Conditionally render the button set
-// - Patient banner
 const FormEngine = ({
   formJson,
   patientUUID,

--- a/src/provider/form-factory-provider.tsx
+++ b/src/provider/form-factory-provider.tsx
@@ -26,7 +26,7 @@ interface FormFactoryProviderContextProps {
   visit: OpenmrsResource;
   location: OpenmrsResource;
   provider: OpenmrsResource;
-  registerForm: (formId: string, context: FormContextProps) => void;
+  registerForm: (formId: string, isSubForm: boolean, context: FormContextProps) => void;
   setCurrentPage: (page: string) => void;
   handleConfirmQuestionDeletion?: (question: Readonly<FormField>) => Promise<void>;
   setIsFormDirty: (isFormDirty: boolean) => void;
@@ -80,11 +80,11 @@ export const FormFactoryProvider: React.FC<FormFactoryProviderProps> = ({
 
   const abortController = new AbortController();
 
-  const registerForm = useCallback((formId: string, context: FormContextProps) => {
-    if (!rootForm.current) {
-      rootForm.current = context;
-    } else if (rootForm.current.formJson.name !== formId) {
+  const registerForm = useCallback((formId: string, isSubForm: boolean, context: FormContextProps) => {
+    if (isSubForm) {
       subForms.current[formId] = context;
+    } else {
+      rootForm.current = context;
     }
   }, []);
 


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

During initialization, the form renderer registers the associated form context with the form-factory provider, which can be either a root form or a subform. This context is stored as an object reference in memory. As the user interacts with the form, the context undergoes mutations as a side-effect. In most cases, these mutations do not cause issues because they occur at deeper levels within the object tree, and most state updates perform shallow clones. However, problems arise when state mutations happen at higher levels, such as with the `formFields` state.

This has caused to a bug with repeating fields, where newly cloned fields do not exist in the factory provider during submission.

---

This fix ensures that state updates are properly propagated, addressing the issue and maintaining consistency across the form context.

## Screenshots
<!-- Required if you are making UI changes. -->
N/A

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
N/A

## Other
<!-- Anything not covered above -->
