### PR TITLE
(fix) Resolve a bug where a NaN value causes an infinite re-render cycle in the Number input

### DIFF
--- a/src/components/inputs/number/number.component.tsx
+++ b/src/components/inputs/number/number.component.tsx
@@ -15,6 +15,13 @@ const NumberField: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
   const [lastBlurredValue, setLastBlurredValue] = useState(value);
   const { layoutType, sessionMode, workspaceLayout } = useFormProviderContext();
 
+  const numberValue = useMemo(() => {
+    if (isNaN(value)) {
+      return '';
+    }
+    return value ?? '';
+  }, [value]);
+
   const onBlur = (event) => {
     event.preventDefault();
     if (lastBlurredValue != value) {
@@ -57,7 +64,7 @@ const NumberField: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
           max={Number(field.questionOptions.max) || undefined}
           min={Number(field.questionOptions.min) || undefined}
           name={field.id}
-          value={value ?? ''}
+          value={numberValue}
           onChange={handleChange}
           onBlur={onBlur}
           allowEmpty={true}

--- a/src/components/inputs/number/number.test.tsx
+++ b/src/components/inputs/number/number.test.tsx
@@ -50,6 +50,19 @@ describe('NumberField Component', () => {
     expect(screen.getByLabelText('Weight(kg):')).toBeInTheDocument();
   });
 
+  it('should render with NaN value', async () => {
+    await renderNumberField({
+      field: numberFieldMock,
+      value: NaN,
+      errors: [],
+      warnings: [],
+      setFieldValue: jest.fn(),
+    });
+
+    const inputElement = screen.getByLabelText('Weight(kg):') as HTMLInputElement;
+    expect(inputElement.value).toBe('');
+  });
+
   it('calls setFieldValue on input change', async () => {
     const mockSetFieldValue = jest.fn();
 


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Carbon's `NumberInput` misbehaves when passed a `NaN` value. This PR addresses this issue by resolving NaN values.

**Bug in action**:  

<img width="1480" alt="Screenshot 2024-10-03 at 21 55 10" src="https://github.com/user-attachments/assets/4150ef3d-41e7-4377-8baf-9821327ee205">

_(The number input fails to render because the calculate expression returns a NaN.)_

## Screenshots
<!-- Required if you are making UI changes. -->

**Fixed**:

<img width="1498" alt="Screenshot 2024-10-03 at 22 00 50" src="https://github.com/user-attachments/assets/9ec786bf-0aac-4433-a111-274d411dc5ca">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
N/A
## Other
<!-- Anything not covered above -->
