### PR TITLE
(fix) Evaluate calculate expressions after general form field initialization

### DIFF
--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -61,7 +61,7 @@ const DateField: React.FC<FormFieldInputProps> = ({ field, value: dateValue, err
         setTime([hours, minutes].join(':'));
       }
     }
-  }, [dateValue]);
+  }, []);
 
   const timePickerLabel = useMemo(
     () =>

--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -54,14 +54,13 @@ const DateField: React.FC<FormFieldInputProps> = ({ field, value: dateValue, err
 
   useEffect(() => {
     if (dateValue) {
-      setFieldValue(dateValue);
       if (dateValue instanceof Date) {
         const hours = dateValue.getHours() < 10 ? `0${dateValue.getHours()}` : `${dateValue.getHours()}`;
         const minutes = dateValue.getMinutes() < 10 ? `0${dateValue.getMinutes()}` : `${dateValue.getMinutes()}`;
         setTime([hours, minutes].join(':'));
       }
     }
-  }, []);
+  }, [dateValue]);
 
   const timePickerLabel = useMemo(
     () =>

--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -54,6 +54,7 @@ const DateField: React.FC<FormFieldInputProps> = ({ field, value: dateValue, err
 
   useEffect(() => {
     if (dateValue) {
+      setFieldValue(dateValue);
       if (dateValue instanceof Date) {
         const hours = dateValue.getHours() < 10 ? `0${dateValue.getHours()}` : `${dateValue.getHours()}`;
         const minutes = dateValue.getMinutes() < 10 ? `0${dateValue.getMinutes()}` : `${dateValue.getMinutes()}`;

--- a/src/components/inputs/date/date.test.tsx
+++ b/src/components/inputs/date/date.test.tsx
@@ -65,24 +65,11 @@ describe('DateField Component', () => {
       value: new Date(),
       errors: [],
       warnings: [],
-      setFieldValue: mockSetFieldValue
+      setFieldValue: mockSetFieldValue,
     });
 
     expect(screen.getByLabelText('Test Date Field')).toBeInTheDocument();
     expect(screen.getByText('Time')).toBeInTheDocument();
-  });
-
-  it('should call setFieldValue with the current date when the form is opened', async () => {
-    const initialDate = new Date();
-    await renderDateField({
-      field: dateFieldMock,
-      value: initialDate,
-      errors: [],
-      warnings: [],
-      setFieldValue: mockSetFieldValue
-    });
-
-    expect(mockSetFieldValue).toHaveBeenCalledWith(initialDate);
   });
 
   it('should display error message when there are errors', async () => {
@@ -91,12 +78,12 @@ describe('DateField Component', () => {
       value: new Date(),
       errors: [{ resultType: 'error', message: 'Error message' }],
       warnings: [],
-      setFieldValue: mockSetFieldValue
+      setFieldValue: mockSetFieldValue,
     });
 
     const errorMessages = screen.getAllByText(/Error message/i);
     expect(errorMessages.length).toBeGreaterThan(0);
-    errorMessages.forEach(message => {
+    errorMessages.forEach((message) => {
       expect(message).toBeInTheDocument();
     });
   });
@@ -108,12 +95,12 @@ describe('DateField Component', () => {
       value: new Date(),
       errors: [],
       warnings: warnings,
-      setFieldValue: mockSetFieldValue
+      setFieldValue: mockSetFieldValue,
     });
 
     const warningMessages = screen.getAllByText(/Warning message/i);
     expect(warningMessages.length).toBeGreaterThan(0);
-    warningMessages.forEach(message => {
+    warningMessages.forEach((message) => {
       expect(message).toBeInTheDocument();
     });
   });

--- a/src/components/inputs/date/date.test.tsx
+++ b/src/components/inputs/date/date.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { useFormProviderContext } from 'src/provider/form-provider';
+import DateField from './date.component';
+import { type FormField } from 'src/types';
+import { OpenmrsDatePicker } from '@openmrs/esm-framework';
+import dayjs from 'dayjs';
+
+jest.mock('src/provider/form-provider', () => ({
+  useFormProviderContext: jest.fn(),
+}));
+
+const mockUseFormProviderContext = useFormProviderContext as jest.Mock;
+const mockSetFieldValue = jest.fn();
+
+const mockOpenmrsDatePicker = jest.mocked(OpenmrsDatePicker);
+
+mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange, isInvalid, invalidText }) => {
+  return (
+    <>
+      <label htmlFor={id}>{labelText}</label>
+      <input
+        id={id}
+        value={value ? dayjs(value as unknown as string).format('DD/MM/YYYY') : ''}
+        onChange={(evt) => {
+          onChange(dayjs(evt.target.value).toDate());
+        }}
+      />
+      {isInvalid && <span>{invalidText}</span>}
+    </>
+  );
+});
+
+const dateFieldMock: FormField = {
+  id: 'test-date-field',
+  label: 'Test Date Field',
+  type: 'obs',
+  datePickerFormat: 'both',
+  questionOptions: {
+    rendering: 'date',
+    concept: '6089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  },
+  isHidden: false,
+  isDisabled: false,
+  readonly: false,
+};
+
+const renderDateField = async (props) => {
+  await act(() => render(<DateField {...props} />));
+};
+
+describe('DateField Component', () => {
+  beforeEach(() => {
+    mockUseFormProviderContext.mockReturnValue({
+      layoutType: 'default',
+      sessionMode: 'edit',
+      workspaceLayout: 'default',
+      formFieldAdapters: {},
+    });
+  });
+
+  it('should render date picker and time picker when datePickerFormat is "both"', async () => {
+    await renderDateField({
+      field: dateFieldMock,
+      value: new Date(),
+      errors: [],
+      warnings: [],
+      setFieldValue: mockSetFieldValue
+    });
+
+    expect(screen.getByLabelText('Test Date Field')).toBeInTheDocument();
+    expect(screen.getByText('Time')).toBeInTheDocument();
+  });
+
+  it('should call setFieldValue with the current date when the form is opened', async () => {
+    const initialDate = new Date();
+    await renderDateField({
+      field: dateFieldMock,
+      value: initialDate,
+      errors: [],
+      warnings: [],
+      setFieldValue: mockSetFieldValue
+    });
+
+    expect(mockSetFieldValue).toHaveBeenCalledWith(initialDate);
+  });
+
+  it('should display error message when there are errors', async () => {
+    await renderDateField({
+      field: dateFieldMock,
+      value: new Date(),
+      errors: [{ resultType: 'error', message: 'Error message' }],
+      warnings: [],
+      setFieldValue: mockSetFieldValue
+    });
+
+    const errorMessages = screen.getAllByText(/Error message/i);
+    expect(errorMessages.length).toBeGreaterThan(0);
+    errorMessages.forEach(message => {
+      expect(message).toBeInTheDocument();
+    });
+  });
+
+  it('should display warning message when there are warnings', async () => {
+    const warnings = [{ resultType: 'warning', message: 'Warning message' }];
+    await renderDateField({
+      field: dateFieldMock,
+      value: new Date(),
+      errors: [],
+      warnings: warnings,
+      setFieldValue: mockSetFieldValue
+    });
+
+    const warningMessages = screen.getAllByText(/Warning message/i);
+    expect(warningMessages.length).toBeGreaterThan(0);
+    warningMessages.forEach(message => {
+      expect(message).toBeInTheDocument();
+    });
+  });
+});

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -215,8 +215,6 @@ export type RenderType =
   | 'toggle'
   | 'ui-select-extended'
   | 'workspace-launcher'
-  | 'fixed-value'
-  | 'file'
   | 'markdown'
   | 'extension-widget'
   | 'select-concept-answers';


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR ensures that the form engine evaluates calculate expressions after the general form field initialization. This ensures that any referenced fields (in the calculate expression) are initialised prior.  

Before:
<img width="707" alt="Screenshot 2024-10-04 at 15 26 36" src="https://github.com/user-attachments/assets/93a14a65-69fe-420c-8029-4425e0abcf28">

Applying any logic would default it to 1970 because of the null value

<img width="1573" alt="Screenshot 2024-10-04 at 15 26 18" src="https://github.com/user-attachments/assets/95e44565-0688-453e-abb2-861dc72394f7">

After: 
<img width="721" alt="Screenshot 2024-10-04 at 15 26 56" src="https://github.com/user-attachments/assets/4f166b71-69e7-4954-9362-e8bbb8a7d7c9">

<img width="1604" alt="Screenshot 2024-10-04 at 15 24 00" src="https://github.com/user-attachments/assets/186c43fa-aa93-4ba3-85e3-1f627e20cce1">


## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
