### PR TITLE
feat (O3-3946): Enable Markdown Formatting for question labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@carbon/react": ">1.47.0 <1.50.0",
     "classnames": "^2.5.1",
+    "html-react-parser": "^5.1.16",
     "lodash-es": "^4.17.21",
     "react-error-boundary": "^4.0.13",
     "react-hook-form": "^7.52.0",

--- a/src/components/field-label/field-label.component.tsx
+++ b/src/components/field-label/field-label.component.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { type FormField } from '../../types';
 import Tooltip from '../inputs/tooltip/tooltip.component';
+import parse from "html-react-parser";
 
 import styles from './field-label.scss';
 
@@ -18,7 +19,7 @@ const FieldLabel: React.FC<FieldLabelProps> = ({ field, customLabel }) => {
   const labelText = customLabel || t(field.label);
   return (
     <div className={styles.questionLabel}>
-      <span>{labelText}</span>
+      <span>{parse(labelText)}</span>
       {field.isRequired && (
         <span title={t('required', 'Required')} className={styles.required}>
           *


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR is comes to extend the work done in this [Pull request](https://github.com/openmrs/openmrs-esm-form-builder/pull/353)
The markdown editor in there returns a question label as an HTML string. So with this change, we are parsing that string using `html-react-parser`.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[https://openmrs.atlassian.net/browse/O3-3946](https://openmrs.atlassian.net/browse/O3-3946)

## Other
<!-- Anything not covered above -->
