### PR TITLE
(fix) Ensure that we use unique React keys in the multi-select component

### DIFF
--- a/src/components/inputs/multi-select/multi-select.component.tsx
+++ b/src/components/inputs/multi-select/multi-select.component.tsx
@@ -104,7 +104,7 @@ const MultiSelect: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
                 initialSelectedItems={initiallySelectedQuestionItems}
                 label={''}
                 titleText={label}
-                key={counter}
+                key={field.id}
                 itemToString={(item) => (item ? item.label : ' ')}
                 disabled={field.isDisabled}
                 invalid={errors.length > 0}
@@ -118,10 +118,10 @@ const MultiSelect: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
                 {field.questionOptions.answers?.map((value, index) => {
                   return (
                     <Checkbox
-                      key={value.concept}
+                      key={`${field.id}-${value.concept}`}
                       className={styles.checkbox}
                       labelText={value.label}
-                      id={value.concept}
+                      id={`${field.id}-${value.concept}`}
                       onChange={() => {
                         handleSelectCheckbox(value);
                       }}


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR fixes an issue were questions (checkbox rendering) with the same concept answers conflict. It fixes the bug by using unique React keys for the underlying components. 
 
## Screenshots
<!-- Required if you are making UI changes. -->

![2024-10-10 16-37-09 2024-10-10 16_38_15](https://github.com/user-attachments/assets/f9c99305-17a2-4343-9847-7467adbca4eb)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4076
## Other
<!-- Anything not covered above -->
