### PR TITLE
(feat) Restore ability to collapse and expand the entire form

### DIFF
--- a/src/components/renderer/form/form-renderer.component.tsx
+++ b/src/components/renderer/form/form-renderer.component.tsx
@@ -24,7 +24,7 @@ export const FormRenderer = ({
   setIsLoadingFormDependencies,
 }: FormRendererProps) => {
   const { evaluatedFields, evaluatedFormJson } = useEvaluateFormFieldExpressions(initialValues, processorContext);
-  const { registerForm, setIsFormDirty, workspaceLayout } = useFormFactory();
+  const { registerForm, setIsFormDirty, workspaceLayout, isFormExpanded } = useFormFactory();
   const methods = useForm({
     defaultValues: initialValues,
   });
@@ -97,7 +97,7 @@ export const FormRenderer = ({
             />
           );
         }
-        return <PageRenderer key={page.label} page={page} />;
+        return <PageRenderer key={page.label} page={page} isFormExpanded={isFormExpanded} />;
       })}
     </FormProvider>
   );

--- a/src/components/renderer/page/page.renderer.component.tsx
+++ b/src/components/renderer/page/page.renderer.component.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useState } from 'react';
-import { type FormPage } from '../../../types';
+import React, { useEffect, useMemo, useState } from 'react';
+import { type FormSection, type FormPage } from '../../../types';
 import { isTrue } from '../../../utils/boolean-utils';
 import { useTranslation } from 'react-i18next';
 import { SectionRenderer } from '../section/section-renderer.component';
@@ -8,12 +8,21 @@ import styles from './page.renderer.scss';
 import { Accordion, AccordionItem } from '@carbon/react';
 import { useFormFactory } from '../../../provider/form-factory-provider';
 import { ChevronDownIcon, ChevronUpIcon } from '@openmrs/esm-framework';
+import classNames from 'classnames';
 
 interface PageRendererProps {
   page: FormPage;
+  isFormExpanded: boolean;
 }
 
-function PageRenderer({ page }: PageRendererProps) {
+interface CollapsibleSectionContainerProps {
+  section: FormSection;
+  sectionIndex: number;
+  visibleSections: FormSection[];
+  isFormExpanded: boolean;
+}
+
+function PageRenderer({ page, isFormExpanded }: PageRendererProps) {
   const { t } = useTranslation();
   const pageId = useMemo(() => page.label.replace(/\s/g, ''), [page.label]);
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -25,6 +34,10 @@ function PageRenderer({ page }: PageRendererProps) {
   });
 
   const toggleCollapse = () => setIsCollapsed(!isCollapsed);
+
+  useEffect(() => {
+    setIsCollapsed(!isFormExpanded);
+  }, [isFormExpanded]);
 
   return (
     <div>
@@ -42,24 +55,50 @@ function PageRenderer({ page }: PageRendererProps) {
               </span>
             </p>
           </div>
-          {!isCollapsed && (
+          <div className={isCollapsed ? styles.hiddenAccordion : styles.accordionContainer}>
             <Accordion>
-              {visibleSections.map((section) => (
-                <AccordionItem
-                  title={t(section.label)}
-                  open={true}
-                  className={styles.sectionContainer}
-                  key={`section-${section.label}`}>
-                  <div className={styles.formSection}>
-                    <SectionRenderer section={section} />
-                  </div>
-                </AccordionItem>
+              {visibleSections.map((section, index) => (
+                <CollapsibleSectionContainer
+                  section={section}
+                  sectionIndex={index}
+                  visibleSections={visibleSections}
+                  isFormExpanded={isFormExpanded}
+                />
               ))}
             </Accordion>
-          )}
+          </div>
         </div>
       </Waypoint>
     </div>
+  );
+}
+
+function CollapsibleSectionContainer({
+  section,
+  sectionIndex,
+  visibleSections,
+  isFormExpanded,
+}: CollapsibleSectionContainerProps) {
+  const { t } = useTranslation();
+  const [isSectionOpen, setIsSectionOpen] = useState(isFormExpanded);
+
+  useEffect(() => {
+    setIsSectionOpen(isFormExpanded);
+  }, [isFormExpanded]);
+
+  return (
+    <AccordionItem
+      title={t(section.label)}
+      open={isSectionOpen}
+      className={classNames(styles.sectionContainer, {
+        [styles.firstSection]: sectionIndex === 0,
+        [styles.lastSection]: sectionIndex === visibleSections.length - 1,
+      })}
+      key={`section-${section.label}`}>
+      <div className={styles.formSection}>
+        <SectionRenderer section={section} />
+      </div>
+    </AccordionItem>
   );
 }
 

--- a/src/components/renderer/page/page.renderer.component.tsx
+++ b/src/components/renderer/page/page.renderer.component.tsx
@@ -28,10 +28,14 @@ function PageRenderer({ page, isFormExpanded }: PageRendererProps) {
   const [isCollapsed, setIsCollapsed] = useState(false);
 
   const { setCurrentPage } = useFormFactory();
-  const visibleSections = page.sections.filter((section) => {
-    const hasVisibleQuestions = section.questions.some((question) => !isTrue(question.isHidden));
-    return !isTrue(section.isHidden) && hasVisibleQuestions;
-  });
+  const visibleSections = useMemo(
+    () =>
+      page.sections.filter((section) => {
+        const hasVisibleQuestions = section.questions.some((question) => !isTrue(question.isHidden));
+        return !isTrue(section.isHidden) && hasVisibleQuestions;
+      }),
+    [page.sections],
+  );
 
   const toggleCollapse = () => setIsCollapsed(!isCollapsed);
 
@@ -55,10 +59,15 @@ function PageRenderer({ page, isFormExpanded }: PageRendererProps) {
               </span>
             </p>
           </div>
-          <div className={isCollapsed ? styles.hiddenAccordion : styles.accordionContainer}>
+          <div
+            className={classNames({
+              [styles.hiddenAccordion]: isCollapsed,
+              [styles.accordionContainer]: !isCollapsed,
+            })}>
             <Accordion>
               {visibleSections.map((section, index) => (
                 <CollapsibleSectionContainer
+                  key={`section-${section.label}`}
                   section={section}
                   sectionIndex={index}
                   visibleSections={visibleSections}
@@ -93,8 +102,7 @@ function CollapsibleSectionContainer({
       className={classNames(styles.sectionContainer, {
         [styles.firstSection]: sectionIndex === 0,
         [styles.lastSection]: sectionIndex === visibleSections.length - 1,
-      })}
-      key={`section-${section.label}`}>
+      })}>
       <div className={styles.formSection}>
         <SectionRenderer section={section} />
       </div>

--- a/src/components/renderer/page/page.renderer.scss
+++ b/src/components/renderer/page/page.renderer.scss
@@ -10,7 +10,8 @@
   transition: background-color 0.1s;
   border-radius: 1px;
   padding: 0.5rem 1rem;
-
+  border-top: 1px solid colors.$gray-20;
+  border-bottom: 1px solid colors.$gray-20;
   &:hover {
     background-color: colors.$gray-20;
   }
@@ -38,8 +39,24 @@
   background-color: colors.$gray-10;
 }
 
+.accordionContainer {
+  width: 95%;
+}
+
+.firstSection {
+  border-top: none;
+}
+
+.lastSection {
+  border-bottom: none !important;
+}
+
 .formSection {
   flex: 1 1 65%;
+}
+
+.hiddenAccordion {
+  display: none;
 }
 
 .formSection > div > fieldset {

--- a/src/form-engine.component.tsx
+++ b/src/form-engine.component.tsx
@@ -16,6 +16,7 @@ import MarkdownWrapper from './components/inputs/markdown/markdown-wrapper.compo
 import { init, teardown } from './lifecycle';
 import { reportError } from './utils/error-utils';
 import { moduleName } from './globals';
+import { useFormCollapse } from './hooks/useFormCollapse';
 
 interface FormEngineProps {
   patientUUID: string;
@@ -62,6 +63,8 @@ const FormEngine = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isFormDirty, setIsFormDirty] = useState(false);
   const sessionMode = !isEmpty(mode) ? mode : !isEmpty(encounterUUID) ? 'edit' : 'enter';
+  const { isFormExpanded, hideFormCollapseToggle } = useFormCollapse(sessionMode);
+
   // TODO: Updating this prop triggers a rerender of the entire form. This means whenever we scroll into a new page, the form is rerendered.
   // Figure out a way to avoid this. Maybe use a ref with an observer instead of a state?
   const [currentPage, setCurrentPage] = useState('');
@@ -118,6 +121,7 @@ const FormEngine = ({
           provider={session?.currentProvider}
           visit={visit}
           handleConfirmQuestionDeletion={handleConfirmQuestionDeletion}
+          isFormExpanded={isFormExpanded}
           formSubmissionProps={{
             isSubmitting,
             setIsSubmitting,
@@ -125,6 +129,7 @@ const FormEngine = ({
             onError: () => {},
             handleClose: () => {},
           }}
+          hideFormCollapseToggle={hideFormCollapseToggle}
           setIsFormDirty={setIsFormDirty}
           setCurrentPage={setCurrentPage}>
           <div className={styles.formContainer}>

--- a/src/provider/form-factory-provider.tsx
+++ b/src/provider/form-factory-provider.tsx
@@ -26,6 +26,7 @@ interface FormFactoryProviderContextProps {
   visit: OpenmrsResource;
   location: OpenmrsResource;
   provider: OpenmrsResource;
+  isFormExpanded: boolean;
   registerForm: (formId: string, isSubForm: boolean, context: FormContextProps) => void;
   setCurrentPage: (page: string) => void;
   handleConfirmQuestionDeletion?: (question: Readonly<FormField>) => Promise<void>;
@@ -41,6 +42,7 @@ interface FormFactoryProviderProps {
   location: OpenmrsResource;
   provider: OpenmrsResource;
   visit: OpenmrsResource;
+  isFormExpanded: boolean;
   children: React.ReactNode;
   formSubmissionProps: {
     isSubmitting: boolean;
@@ -49,6 +51,7 @@ interface FormFactoryProviderProps {
     onError: (error: any) => void;
     handleClose: () => void;
   };
+  hideFormCollapseToggle: () => void;
   setCurrentPage: (page: string) => void;
   handleConfirmQuestionDeletion?: (question: Readonly<FormField>) => Promise<void>;
   setIsFormDirty: (isFormDirty: boolean) => void;
@@ -65,8 +68,10 @@ export const FormFactoryProvider: React.FC<FormFactoryProviderProps> = ({
   location,
   provider,
   visit,
+  isFormExpanded = true,
   children,
   formSubmissionProps,
+  hideFormCollapseToggle,
   setCurrentPage,
   handleConfirmQuestionDeletion,
   setIsFormDirty,
@@ -121,6 +126,7 @@ export const FormFactoryProvider: React.FC<FormFactoryProviderProps> = ({
             if (postSubmissionHandlers) {
               await processPostSubmissionActions(postSubmissionHandlers, results, patient, sessionMode, t);
             }
+            hideFormCollapseToggle();
             if (onSubmit) {
               onSubmit(results);
             } else {
@@ -162,6 +168,7 @@ export const FormFactoryProvider: React.FC<FormFactoryProviderProps> = ({
         visit,
         location,
         provider,
+        isFormExpanded,
         registerForm,
         setCurrentPage,
         handleConfirmQuestionDeletion,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR primarily restores the ability to collapse and expand all visible form pages and sections.

**Out of scope**:
1. **Unmounting Issue**: This PR resolves an issue where toggling between expanding and collapsing a page caused its child sections to unmount from the DOM. This was addressed by removing the conditional rendering of sections within the PageRenderer.
2. **UI Enhancements**: Additionally, this PR introduces UI tweaks that visually nest sections within their respective page containers. 

## Screenshots
<!-- Required if you are making UI changes. -->
**Unmounting Issue:**

![2024-10-16 01-12-03 2024-10-16 01_13_21](https://github.com/user-attachments/assets/7c14d02d-4232-43aa-85ea-f06c97070722)
_(The Encounter Provider and Location fields are remounted)_

**Unmounting Issue Fixed:**

![2024-10-16 01-13-56 2024-10-16 01_15_33](https://github.com/user-attachments/assets/cfd34294-c956-4b0b-8058-053de497219d)

**Other features:**

![2024-10-16 01-15-45 2024-10-16 01_20_02](https://github.com/user-attachments/assets/9d6c29ce-95a1-4400-8ea7-e8a44f51bcb4)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
N/A

## Other
<!-- Anything not covered above -->
Note: Carbon doesn't support nesting accordions, which is why I resorted to manipulating the visibility of the sections during page collapse; see:
- https://github.com/carbon-design-system/carbon/issues/7328
- https://github.com/carbon-design-system/carbon/issues/14840
