### PR TITLE
(test) Auto-clear jest mocks

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('jest').Config} */
 module.exports = {
   verbose: true,
+  clearMocks: true,
   collectCoverage: true,
   coverageThreshold: {
     global: {

--- a/src/utils/form-helper.test.ts
+++ b/src/utils/form-helper.test.ts
@@ -129,10 +129,6 @@ describe('Form Engine Helper', () => {
   //     setEncounterRole: jest.fn(),
   //   };
 
-  //   beforeEach(() => {
-  //     jest.clearAllMocks();
-  //   });
-
   //   it('should return true if rendering is toggle and default value is ConceptTrue', () => {
   //     const sampleField: FormField = {
   //       label: 'Sample Toggle Field',


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR adds a `clearMocks` option to the Jest config to automatically [clear mocks](https://jestjs.io/docs/configuration#clearmocks-boolean) between tests. With this, you don't need to manually clear mocks in beforeEach blocks.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
