### PR TITLE
(fix) Await for async calculate expressions to resolve at initialisation

### DIFF
--- a/src/processors/encounter/encounter-form-processor.ts
+++ b/src/processors/encounter/encounter-form-processor.ts
@@ -273,13 +273,15 @@ export class EncounterFormProcessor extends FormProcessor {
           }
         }),
       );
-      fieldsWithCalculateExpressions.forEach(async (field) => {
-        try {
-          await evaluateCalculateExpression(field, initialValues, context);
-        } catch (error) {
-          console.error(error);
-        }
-      });
+      await Promise.all(
+        fieldsWithCalculateExpressions.map(async (field) => {
+          try {
+            await evaluateCalculateExpression(field, initialValues, context);
+          } catch (error) {
+            console.error(error);
+          }
+        }),
+      );
     }
     return initialValues;
   }


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This fix resolves an issue where initial values from calculateExpressions weren't being persisted. This was mostly because the expressions are promises and the values were being set before the promise is resolved. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
