### PR TITLE
(fix) Render date readonly same as view mode

### DIFF
--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -72,7 +72,7 @@ const DateField: React.FC<FormFieldInputProps> = ({ field, value: dateValue, err
     [field.datePickerFormat, field.label, t],
   );
 
-  return sessionMode == 'view' || sessionMode == 'embedded-view' ? (
+  return sessionMode == 'view' || sessionMode == 'embedded-view' || isTrue(field.readonly) ? (
     <FieldValueView
       label={t(field.label)}
       value={dateValue instanceof Date ? formatDateAsDisplayString(field, dateValue) : dateValue}

--- a/src/components/label/label.scss
+++ b/src/components/label/label.scss
@@ -8,4 +8,8 @@
   :global(.cds--label) {
     font-weight: bolder;
   }
+
+  button {
+    border-bottom: none !important;
+  }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
The Openmrs datepicker doesn't currently support native readonly mode, this changes so that the date field renders same as view mode when readonly is `true`

## Screenshots

<img width="586" alt="Screenshot 2024-10-24 at 09 47 19" src="https://github.com/user-attachments/assets/8a1a8a5b-e80c-49d0-9cd0-01e1d0680df4">



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
