### PR TITLE
(test) O3-3926-Add test coverage for the InlineDateAdapter

### DIFF
--- a/src/adapters/inline-date-adapter.test.ts
+++ b/src/adapters/inline-date-adapter.test.ts
@@ -1,0 +1,99 @@
+import { InlineDateAdapter } from './inline-date-adapter';
+import { parseDate, toOmrsIsoString } from '@openmrs/esm-framework';
+
+describe('InlineDateAdapter', () => {
+  let field;
+  let context;
+  let targetField;
+  
+  beforeEach(() => {
+    targetField = {
+      id: 'temperature',
+      questionOptions: {
+        concept: '2c43u05b-b6d8-4eju-8f37-0b14f5347560',
+        rendering: 'number'
+      },
+      value: '36',
+      meta: {}
+    };
+    
+    field = {
+      id: 'temperature_inline_date',
+      meta: {
+        targetField: 'temperature'
+      }
+    };
+    
+    context = {
+      getFormField: jest.fn().mockReturnValue(targetField),
+      methods: {
+        getValues: jest.fn().mockReturnValue('36')
+      },
+      formFields: [targetField]
+    };
+  });
+
+  it('should overwrite the target field obs date prop value', () => {
+    const newDate = new Date('2024-04-01T19:50:00.000+0000');
+    targetField.meta.submission = {
+      newValue: { value: '36' }
+    };
+
+    InlineDateAdapter.transformFieldValue(field, newDate, context);
+
+    expect(targetField.meta.submission.newValue.obsDatetime).toBe(toOmrsIsoString(newDate));
+  });
+
+  it('should edit a previously associated date while in edit mode', () => {
+    const newDate = new Date('2024-04-01T19:50:00.000+0000');
+    targetField.meta.previousValue = {
+      obsDatetime: '2024-04-01T19:40:40.000+0000',
+      value: '36'
+    };
+
+    InlineDateAdapter.transformFieldValue(field, newDate, context);
+
+    expect(targetField.meta.submission.newValue.obsDatetime).toBe(toOmrsIsoString(newDate));
+  });
+
+  it('should only commit side-effects if the previous date value changes', () => {
+    const existingDate = new Date('2024-04-01T19:50:00.000+0000');
+    targetField.meta.previousValue = {
+      obsDatetime: toOmrsIsoString(existingDate),
+      value: '36',
+    };
+    InlineDateAdapter.transformFieldValue(field, existingDate, context);
+
+    expect(targetField.meta.submission).toBeUndefined();
+  });
+
+  it('should commit side-effects if the target field has a value or submission', () => {
+    const newDate = new Date('2024-04-01T19:50:00.000+0000');
+    targetField.meta.previousValue = {
+      value: '36'
+    };
+
+    InlineDateAdapter.transformFieldValue(field, newDate, context);
+
+    expect(targetField.meta.submission.newValue.obsDatetime).toBe(toOmrsIsoString(newDate));
+  });
+
+  it('should extract initial value from the target field obs value', () => {
+    const encounter = {
+      uuid: '873455da-3ec4-453c-b565-7c1fe35426be',
+      obs: [{
+        concept: { uuid: '2c43u05b-b6d8-4eju-8f37-0b14f5347560' },
+        value: '36',
+        obsDatetime: '2024-04-01T19:50:00.000+0000'
+      }]
+    };
+
+    targetField.meta.previousValue = {
+      obsDatetime: '2024-04-01T19:50:00.000+0000'
+    };
+
+    const result = InlineDateAdapter.getInitialValue(field, encounter, context);
+
+    expect(result).toEqual(parseDate('2024-04-01T19:50:00.000+0000'));
+  });
+});


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR introduces test coverage for the InlineDateAdapter to ensure robust handling of date transformations within form fields. Key scenarios tested include:

    Updating Observation Dates: Tests confirm that when a new date is provided, the adapter correctly updates the obsDatetime field in the target field’s submission, ensuring accuracy in new entries.

    Editing Dates in Edit Mode: Verifies that the adapter updates dates accurately when modified in edit mode, supporting seamless updates to existing records.

    Conditional Side-Effects: Tests check that side-effects only trigger when there’s an actual change in the date value, avoiding redundant updates.

    Commitment on Value Presence: Ensures side-effects are committed if the target field holds a value or has an existing submission, facilitating reliable updates when data is available.

    Initial Value Extraction: Confirms that the adapter retrieves initial observation dates correctly from the previous value, essential for accurate pre-filling.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-3926

## Other
<!-- Anything not covered above -->
