### PR TITLE
(fix) Properly sanitize and initialize cloned fields

### DIFF
--- a/src/components/inputs/text/text.component.tsx
+++ b/src/components/inputs/text/text.component.tsx
@@ -42,7 +42,9 @@ const TextField: React.FC<FormFieldInputProps> = ({ field, value, errors, warnin
           <TextInput
             id={field.id}
             labelText={<FieldLabel field={field} />}
-            onChange={setFieldValue}
+            onChange={(event) => {
+              setFieldValue(event.target.value);
+            }}
             onBlur={onBlur}
             name={field.id}
             value={value}

--- a/src/components/inputs/text/text.test.tsx
+++ b/src/components/inputs/text/text.test.tsx
@@ -161,17 +161,11 @@ describe('Text field input', () => {
   it('should record new obs', async () => {
     await renderForm(textValues);
     const inputField = screen.getByLabelText('Indicate your notes');
-
-    await user.type(inputField, 'Updated patient notes');
+    await user.click(inputField);
+    await user.paste('Updated patient notes');
 
     await act(async () => {
-      expect(mockSetFieldValue).toHaveBeenCalledWith(
-        expect.objectContaining({
-          target: expect.objectContaining({
-            value: 'Updated patient notes',
-          }),
-        }),
-      );
+      expect(mockSetFieldValue).toHaveBeenCalledWith('Updated patient notes');
     });
   });
 

--- a/src/components/renderer/field/form-field-renderer.component.tsx
+++ b/src/components/renderer/field/form-field-renderer.component.tsx
@@ -2,10 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 import {
   type FormField,
   type FormFieldInputProps,
-  type FormFieldValidator,
   type FormFieldValueAdapter,
   type RenderType,
-  type SessionMode,
   type ValidationResult,
   type ValueAndDisplay,
 } from '../../../types';

--- a/src/components/renderer/form/form-renderer.component.tsx
+++ b/src/components/renderer/form/form-renderer.component.tsx
@@ -6,7 +6,6 @@ import { formStateReducer, initialState } from './state';
 import { useEvaluateFormFieldExpressions } from '../../../hooks/useEvaluateFormFieldExpressions';
 import { useFormFactory } from '../../../provider/form-factory-provider';
 import { FormProvider, type FormContextProps } from '../../../provider/form-provider';
-import { isTrue } from '../../../utils/boolean-utils';
 import { type FormProcessorContextProps } from '../../../types';
 import { useFormStateHelpers } from '../../../hooks/useFormStateHelpers';
 import { pageObserver } from '../../sidebar/page-observer';

--- a/src/components/repeat/helpers.ts
+++ b/src/components/repeat/helpers.ts
@@ -15,6 +15,7 @@ export function cloneRepeatField(srcField: FormField, value: OpenmrsResource, id
     childField.id = `${childField.id}_${idSuffix}`;
     childField.meta.groupId = clonedField.id;
     childField.meta.previousValue = null;
+    childField.fieldDependents = new Set();
     clearSubmission(childField);
 
     // cleanup expressions

--- a/src/components/repeat/repeat.component.tsx
+++ b/src/components/repeat/repeat.component.tsx
@@ -48,7 +48,7 @@ const Repeat: React.FC<FormFieldInputProps> = ({ field }) => {
 
   const handleAdd = useCallback(
     (counter: number) => {
-      const clonedFieldsBuffer = [];
+      const clonedFieldsBuffer: FormField[] = [];
       function evaluateExpressions(field: FormField) {
         if (field.hide?.hideWhenExpression) {
           field.isHidden = evaluateExpression(
@@ -82,6 +82,8 @@ const Repeat: React.FC<FormFieldInputProps> = ({ field }) => {
       }
       const clonedField = cloneRepeatField(field, null, counter);
       clonedFieldsBuffer.push(clonedField);
+
+      // Handle nested questions
       if (clonedField.type === 'obsGroup') {
         clonedField.questions?.forEach((childField) => {
           clonedFieldsBuffer.push(childField);

--- a/src/components/repeat/repeat.component.tsx
+++ b/src/components/repeat/repeat.component.tsx
@@ -48,12 +48,13 @@ const Repeat: React.FC<FormFieldInputProps> = ({ field }) => {
 
   const handleAdd = useCallback(
     (counter: number) => {
+      const clonedFieldsBuffer = [];
       function evaluateExpressions(field: FormField) {
         if (field.hide?.hideWhenExpression) {
           field.isHidden = evaluateExpression(
             field.hide.hideWhenExpression,
             { value: field, type: 'field' },
-            formFields,
+            [...formFields, ...clonedFieldsBuffer],
             getValues(),
             {
               mode: sessionMode,
@@ -65,7 +66,7 @@ const Repeat: React.FC<FormFieldInputProps> = ({ field }) => {
           evaluateAsyncExpression(
             field.questionOptions.calculate?.calculateExpression,
             { value: field, type: 'field' },
-            formFields,
+            [...formFields, ...clonedFieldsBuffer],
             getValues(),
             {
               mode: sessionMode,
@@ -80,16 +81,17 @@ const Repeat: React.FC<FormFieldInputProps> = ({ field }) => {
         }
       }
       const clonedField = cloneRepeatField(field, null, counter);
-      // run necessary expressions
+      clonedFieldsBuffer.push(clonedField);
       if (clonedField.type === 'obsGroup') {
         clonedField.questions?.forEach((childField) => {
-          evaluateExpressions(childField);
-          addFormField(childField);
+          clonedFieldsBuffer.push(childField);
         });
-      } else {
-        evaluateExpressions(clonedField);
       }
-      addFormField(clonedField);
+
+      clonedFieldsBuffer.forEach((field) => {
+        evaluateExpressions(field);
+        addFormField(field);
+      });
       setRows([...rows, clonedField]);
     },
     [formFields, field, rows, context],

--- a/src/hooks/useFormStateHelpers.ts
+++ b/src/hooks/useFormStateHelpers.ts
@@ -8,9 +8,24 @@ export function useFormStateHelpers(dispatch: Dispatch<Action>, formFields: Form
   const addFormField = useCallback((field: FormField) => {
     dispatch({ type: 'ADD_FORM_FIELD', value: field });
   }, []);
-  const updateFormField = useCallback((field: FormField) => {
-    dispatch({ type: 'UPDATE_FORM_FIELD', value: cloneDeep(field) });
-  }, []);
+  const updateFormField = useCallback(
+    (field: FormField) => {
+      if (field.meta.groupId) {
+        const group = formFields.find((f) => f.id === field.meta.groupId);
+        if (group) {
+          group.questions = group.questions.map((child) => {
+            if (child.id === field.id) {
+              return field;
+            }
+            return child;
+          });
+          updateFormField(group);
+        }
+      }
+      dispatch({ type: 'UPDATE_FORM_FIELD', value: cloneDeep(field) });
+    },
+    [formFields],
+  );
 
   const getFormField = useCallback(
     (fieldId: string) => {


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR fixes an issue where cloned fields skip logic doesn't work as expected within obs group instances. The issue has been fixed by including all form fields (including the freshly cloned fields) in the expression runner's context. 

## Screenshots
<!-- Required if you are making UI changes. -->

Issue:

https://github.com/user-attachments/assets/4b35b0f9-45af-4ff0-b6d8-54bd302d7445


Fixed:

![2024-11-25 14-59-43 2024-11-25 15_00_54](https://github.com/user-attachments/assets/217355ff-7fbc-4c5f-9b75-c27aa9e88dd2)



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4157

## Other
<!-- Anything not covered above -->
