### PR TITLE
(fix) Make extraction of the calculated value null safe

### DIFF
--- a/src/adapters/obs-adapter.ts
+++ b/src/adapters/obs-adapter.ts
@@ -7,6 +7,7 @@ import {
   type AttachmentResponse,
   type Attachment,
   type ValueAndDisplay,
+  type FormFieldValueAdapter,
 } from '../types';
 import {
   hasRendering,
@@ -17,7 +18,6 @@ import {
   formatDateAsDisplayString,
 } from '../utils/common-utils';
 import { type FormContextProps } from '../provider/form-provider';
-import { type FormFieldValueAdapter } from '../types';
 import { isEmpty } from '../validators/form-validator';
 import { getAttachmentByUuid } from '../api';
 import { formatDate, restBaseUrl } from '@openmrs/esm-framework';

--- a/src/components/renderer/field/fieldLogic.ts
+++ b/src/components/renderer/field/fieldLogic.ts
@@ -1,3 +1,4 @@
+import { reportError } from 'src/utils/error-utils';
 import { codedTypes } from '../../../constants';
 import { type FormContextProps } from '../../../provider/form-provider';
 import { type FormFieldValidator, type SessionMode, type ValidationResult, type FormField } from '../../../types';
@@ -80,6 +81,8 @@ function evaluateFieldDependents(field: FormField, values: any, context: FormCon
             context.formFieldAdapters[dependent.type].transformFieldValue(dependent, result, context);
           }
           updateFormField(dependent);
+        }).catch((error) => {
+          reportError(error, 'Error evaluating calculate expression');
         });
       }
       // evaluate hide

--- a/src/components/renderer/field/fieldLogic.ts
+++ b/src/components/renderer/field/fieldLogic.ts
@@ -1,4 +1,3 @@
-import { reportError } from 'src/utils/error-utils';
 import { codedTypes } from '../../../constants';
 import { type FormContextProps } from '../../../provider/form-provider';
 import { type FormFieldValidator, type SessionMode, type ValidationResult, type FormField } from '../../../types';
@@ -7,6 +6,7 @@ import { hasRendering } from '../../../utils/common-utils';
 import { evaluateAsyncExpression, evaluateExpression } from '../../../utils/expression-runner';
 import { evalConditionalRequired, evaluateDisabled, evaluateHide } from '../../../utils/form-helper';
 import { isEmpty } from '../../../validators/form-validator';
+import { reportError } from '../../../utils/error-utils';
 
 export function handleFieldLogic(field: FormField, context: FormContextProps) {
   const {

--- a/src/components/renderer/field/form-field-renderer.component.tsx
+++ b/src/components/renderer/field/form-field-renderer.component.tsx
@@ -2,10 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 import {
   type FormField,
   type FormFieldInputProps,
-  type FormFieldValidator,
   type FormFieldValueAdapter,
   type RenderType,
-  type SessionMode,
   type ValidationResult,
   type ValueAndDisplay,
 } from '../../../types';

--- a/src/processors/encounter/encounter-form-processor.ts
+++ b/src/processors/encounter/encounter-form-processor.ts
@@ -318,7 +318,7 @@ export class EncounterFormProcessor extends FormProcessor {
         patient: patient,
         previousEncounter: previousDomainObjectValue,
       });
-      return extractObsValueAndDisplay(field, value);
+      return value ? extractObsValueAndDisplay(field, value) : null;
     }
     if (previousDomainObjectValue && field.questionOptions.enablePreviousValue) {
       return await adapter.getPreviousValue(field, previousDomainObjectValue, context);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Makes extraction of calculated value null safe in scenarios where return value differs

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
