### PR TITLE
(fix) Update obs group state when a group member changes

### DIFF
--- a/src/components/renderer/field/form-field-renderer.component.tsx
+++ b/src/components/renderer/field/form-field-renderer.component.tsx
@@ -46,6 +46,7 @@ export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: Form
     formFieldValidators,
     addInvalidField,
     removeInvalidField,
+    updateFormField,
   } = context;
 
   const fieldValue = useWatch({ control, name: fieldId, exact: true });
@@ -132,6 +133,18 @@ export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: Form
     }
     setWarnings(validationWarnings);
     handleFieldLogic(field, context);
+    if (field.meta.groupId) {
+      const group = formFields.find((f) => f.id === field.meta.groupId);
+      if (group) {
+        group.questions = group.questions.map((child) => {
+          if (child.id === field.id) {
+            return field;
+          }
+          return child;
+        });
+        updateFormField(group);
+      }
+    }
   };
 
   if (!inputComponentWrapper) {

--- a/src/form-engine.test.tsx
+++ b/src/form-engine.test.tsx
@@ -877,6 +877,49 @@ describe('Form engine component', () => {
   });
 
   describe('Obs group', () => {
+    it('should save obs group on form submission', async () => {
+      const saveEncounterMock = jest.spyOn(api, 'saveEncounter');
+      await act(async () => {
+        renderForm(null, obsGroupTestForm);
+      });
+
+      // Fill out the obs group fields
+      const dateOfBirth = screen.getByRole('textbox', { name: /date of birth/i });
+      const maleRadio = screen.getByRole('radio', { name: /^male$/i });
+
+      await user.click(dateOfBirth);
+      await user.paste('2020-09-09T00:00:00.000Z');
+      await user.click(maleRadio);
+
+      // Submit the form
+      await user.click(screen.getByRole('button', { name: /save/i }));
+
+      // Verify the encounter was saved with the correct structure
+      expect(saveEncounterMock).toHaveBeenCalledTimes(1);
+
+      const [_, encounter] = saveEncounterMock.mock.calls[0];
+      expect(encounter.obs.length).toBe(1);
+      expect(encounter.obs[0]).toEqual({
+        groupMembers: [
+          {
+            value: '1534AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            concept: '1587AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            formFieldNamespace: 'rfe-forms',
+            formFieldPath: 'rfe-forms-childSex',
+          },
+          {
+            value: '2020-09-09',
+            concept: '164802AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            formFieldNamespace: 'rfe-forms',
+            formFieldPath: 'rfe-forms-birthDate',
+          },
+        ],
+        concept: '1c70c490-cafa-4c95-9fdd-a30b62bb78b8',
+        formFieldNamespace: 'rfe-forms',
+        formFieldPath: 'rfe-forms-myGroup',
+      });
+    });
+
     it('should test addition of a repeating group', async () => {
       await act(async () => {
         renderForm(null, obsGroupTestForm);


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [X] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Added logic to update an obs group’s state whenever a group member’s state changes.
- This ensures consistency in forms with flattened fields by keeping the group in sync with its members.
## Screenshots
<!-- Required if you are making UI changes. -->
![2024-12-03 14-04-18 2024-12-03 14_07_12](https://github.com/user-attachments/assets/328ba312-9129-4c8a-8718-ce4ba49efea8)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
