### PR TITLE
(feat) O3-3911 Display all items on ui-select-extended

### DIFF
--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -148,13 +148,7 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
             itemToString={(item) => item?.display}
             selectedItem={selectedItem}
             placeholder={isSearchable ? t('search', 'Search') + '...' : null}
-            shouldFilterItem={({ item, inputValue }) => {
-              if (!inputValue) {
-                // Carbon's initial call at component mount
-                return true;
-              }
-              return item.display?.toLowerCase().includes(inputValue.toLowerCase());
-            }}
+            shouldFilterItem={() => true}
             onChange={({ selectedItem }) => {
               isProcessingSelection.current = true;
               setFieldValue(selectedItem?.uuid);

--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -148,7 +148,6 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
             itemToString={(item) => item?.display}
             selectedItem={selectedItem}
             placeholder={isSearchable ? t('search', 'Search') + '...' : null}
-            shouldFilterItem={() => true}
             onChange={({ selectedItem }) => {
               isProcessingSelection.current = true;
               setFieldValue(selectedItem?.uuid);

--- a/src/components/inputs/ui-select-extended/ui-select-extended.test.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.test.tsx
@@ -267,7 +267,7 @@ describe('UiSelectExtended', () => {
       expect(screen.getByText('Naguru')).toBeInTheDocument();
       expect(screen.getByText('Muyenga')).toBeInTheDocument();
     
-      // Type some input
+      // Type input
       await user.type(transferLocationSelect, 'Nag');
     
       // Verify all items are still displayed

--- a/src/components/inputs/ui-select-extended/ui-select-extended.test.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.test.tsx
@@ -253,18 +253,27 @@ describe('UiSelectExtended', () => {
       );
     });
 
-    it('should filter items based on user input', async () => {
+    it('should display all items regardless of user input', async () => {
       await act(async () => {
         renderForm();
       });
 
-      const transferLocationSelect = await findSelectInput(screen, 'Transfer Location');
+      const transferLocationSelect = await findSelectInput(screen, 'Transfer Location');    
+      // Open the dropdown
       await user.click(transferLocationSelect);
-      await user.type(transferLocationSelect, 'Nag');
-
+    
+      // Verify all items are displayed initially
+      expect(screen.getByText('Kololo')).toBeInTheDocument();
       expect(screen.getByText('Naguru')).toBeInTheDocument();
-      expect(screen.queryByText('Kololo')).not.toBeInTheDocument();
-      expect(screen.queryByText('Muyenga')).not.toBeInTheDocument();
+      expect(screen.getByText('Muyenga')).toBeInTheDocument();
+    
+      // Type some input
+      await user.type(transferLocationSelect, 'Nag');
+    
+      // Verify all items are still displayed
+      expect(screen.getByText('Kololo')).toBeInTheDocument();
+      expect(screen.getByText('Naguru')).toBeInTheDocument();
+      expect(screen.getByText('Muyenga')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- Updated shouldFilterItem to always return true, ensuring all items are displayed when the caret is clicked.
- Adjusted tests to validate that all items remain visible even after typing input.

## Screenshots

https://github.com/user-attachments/assets/85e7989e-39fc-44df-9876-0f7bfd686a2d


## Related Issue
https://openmrs.atlassian.net/browse/O3-3911

## Other
<!-- Anything not covered above -->
