### PR TITLE
(refactor) Tweak calcMonthsOnART helper logic

### DIFF
--- a/src/utils/common-expression-helpers.test.ts
+++ b/src/utils/common-expression-helpers.test.ts
@@ -171,7 +171,7 @@ describe('CommonExpressionHelpers', () => {
     it('should return the correct number of months on ART', () => {
       const artStartDate = new Date('2020-01-01');
       const today = new Date();
-      const monthsOnART = Math.floor((today.getTime() - artStartDate.getTime()) / (1000 * 60 * 60 * 24 * 30));
+      const monthsOnART = dayjs(today).diff(dayjs(artStartDate), 'months');
       expect(helpers.calcMonthsOnART(artStartDate)).toBe(monthsOnART);
     });
 

--- a/src/utils/common-expression-helpers.ts
+++ b/src/utils/common-expression-helpers.ts
@@ -118,19 +118,22 @@ export class CommonExpressionHelpers {
   };
 
   calcMonthsOnART = (artStartDate: Date) => {
-    if (artStartDate == null) return null;
+    if (artStartDate == null) {
+      return null;
+    }
 
     if (!(artStartDate instanceof Date)) {
       throw new Error('DateFormatException: value passed is not a valid date');
     }
 
-    let today = new Date();
-    let resultMonthsOnART: number;
-    let artInDays = Math.round((today.getTime() - artStartDate.getTime?.()) / 86400000);
-    if (artStartDate && artInDays >= 30) {
-      resultMonthsOnART = Math.floor(artInDays / 30);
+    const today = new Date();
+    const artInDays = Math.round((today.getTime() - artStartDate.getTime()) / 86400000);
+
+    if (artInDays < 30) {
+      return 0;
     }
-    return artStartDate ? resultMonthsOnART : null;
+
+    return dayjs(today).diff(artStartDate, 'month');
   };
 
   calcViralLoadStatus = (viralLoadCount: number) => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Tweaks the logic of the `calcMonthsOnART` expression helper function to use dayjs for more accurate month calculation. Presently, it only calculates months if at least 30 days have passed since the ART start date. It does so by calculating the difference in days between today and the ART start date, and then dividing by 30.

This PR changes the logic to use dayjs to calculate the difference in months between today and the ART start date. The motivation for this change is to fix a failing test on the main branch that arose from the previous logic.

## Screenshots

### Failing test on `main`

![CleanShot 2024-12-04 at 11  15 41@2x](https://github.com/user-attachments/assets/21792aff-bf3a-436d-b6f5-630d2df20864)

### [Failing test in CI](https://github.com/openmrs/openmrs-esm-form-engine-lib/actions/runs/12164829880/job/33927422326?pr=438)

![CleanShot 2024-12-04 at 11  17 47@2x](https://github.com/user-attachments/assets/c2420f26-44b7-40d5-b733-0b13cf6a98a5)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

### Test plan

@samuelmale could you advise on an appropriate test plan for this change?
