### PR TITLE
(fix) Hide empty obs groups

### DIFF
--- a/__mocks__/forms/rfe-forms/obs-group-test_form.json
+++ b/__mocks__/forms/rfe-forms/obs-group-test_form.json
@@ -1,137 +1,201 @@
 {
-    "name": "ObsGroup Test Form",
-    "version": "1",
-    "published": true,
-    "retired": false,
-    "pages": [
-      {
-        "label": "Introduction",
-        "sections": [
-          {
-            "label": "",
-            "isExpanded": "true",
-            "questions": [
-              {
-                "type": "markdown",
-                "questionOptions": {
-                  "rendering": "markdown"
-                },
-                "id": "fooMarkdown",
-                "value": [
-                  "**Use this form to:** Test Obs Group behaviour"
-                ]
-              }
-            ]
-          }
-        ]
-      }, 
-      {
-        "label": "Obs Group Page",
-        "sections": [
-          {
-            "label": "Group Section",
-            "isExpanded": "true",
-            "questions": [
-              {
-                "id": "myGroup",
-                "label": "My Group",
-                "type": "obsGroup",
-                "questionOptions": {
-                  "rendering": "repeating",
-                  "concept": "1c70c490-cafa-4c95-9fdd-a30b62bb78b8"
-                },
-                "behaviours":[
-                  {
-                    "intent":"*",
-                    "required":"false",
-                    "unspecified":"false",
-                    "hide":{
-                      "hideWhenExpression":""
-                    },
-                    "validators":[]
-                  }
-                ],
-                "questions": [
-                  {
-                    "label": "Sex",
-                    "type":"obs",
-                    "required":"true",
-                    "questionOptions":{
-                      "rendering":"radio",
-                      "concept":"1587AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      "answers":[
-                        {
-                          "concept":"1535AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                          "label":"Female"
-                        },
-                        {
-                          "concept":"1534AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                          "label":"Male"
-                        }
-                      ]
-                    },
-                    "id":"childSex",
-                    "behaviours":[
+  "name": "ObsGroup Test Form",
+  "version": "1",
+  "published": true,
+  "retired": false,
+  "pages": [
+    {
+      "label": "Obs Group Page",
+      "sections": [
+        {
+          "label": "Group Section",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "id": "myGroup",
+              "label": "My Group",
+              "type": "obsGroup",
+              "questionOptions": {
+                "rendering": "repeating",
+                "concept": "1c70c490-cafa-4c95-9fdd-a30b62bb78b8"
+              },
+              "behaviours": [
+                {
+                  "intent": "*",
+                  "required": "false",
+                  "unspecified": "false",
+                  "hide": {
+                    "hideWhenExpression": ""
+                  },
+                  "validators": []
+                }
+              ],
+              "questions": [
+                {
+                  "label": "Sex",
+                  "type": "obs",
+                  "required": "true",
+                  "questionOptions": {
+                    "rendering": "radio",
+                    "concept": "1587AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "answers": [
                       {
-                        "intent":"*",
-                        "required":"true",
-                        "unspecified":"true",
-                        "hide":{
-                          "hideWhenExpression":"false"
-                        },
-                        "validators":[]
+                        "concept": "1535AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "label": "Female"
+                      },
+                      {
+                        "concept": "1534AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "label": "Male"
                       }
                     ]
                   },
-                  {
-                    "label": "Date of Birth",
-                    "type": "obs",
-                    "questionOptions": {
-                      "rendering": "date",
-                      "concept": "164802AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                      "weeksList": ""
-                    },
-                    "id": "birthDate",
-                    "behaviours": [
-                      {
-                        "intent": "*",
-                        "required": "true",
-                        "unspecified": "true",
-                        "hide": {
-                          "hideWhenExpression": "false"
+                  "id": "childSex",
+                  "behaviours": [
+                    {
+                      "intent": "*",
+                      "required": "true",
+                      "unspecified": "true",
+                      "hide": {
+                        "hideWhenExpression": "false"
+                      },
+                      "validators": []
+                    }
+                  ]
+                },
+                {
+                  "label": "Date of Birth",
+                  "type": "obs",
+                  "questionOptions": {
+                    "rendering": "date",
+                    "concept": "164802AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "weeksList": ""
+                  },
+                  "id": "birthDate",
+                  "behaviours": [
+                    {
+                      "intent": "*",
+                      "required": "true",
+                      "unspecified": "true",
+                      "hide": {
+                        "hideWhenExpression": "false"
+                      },
+                      "validators": [
+                        {
+                          "type": "date",
+                          "allowFutureDates": "false"
                         },
-                        "validators": [
-                          {
-                            "type": "date",
-                            "allowFutureDates": "false"
-                          },
-                          {
-                            "type": "js_expression",
-                            "failsWhenExpression": "!isDateEqualTo(myValue, useFieldValue('visit_date'))",
-                            "message": "Child birth date should be the same as the visit date!"
-                          }
-                        ]
-                      }
-                    ]
+                        {
+                          "type": "js_expression",
+                          "failsWhenExpression": "!isDateEqualTo(myValue, useFieldValue('visit_date'))",
+                          "message": "Child birth date should be the same as the visit date!"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Screening Section",
+          "questions": [
+            {
+              "label": "Do you have dependents?",
+              "id": "hasDependents",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "a89e3f94-1350-11df-a1f1-0026b9348837",
+                "answers": [
+                  {
+                    "concept": "a89ce50e-1350-11df-a1f1-0026b9348839",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "a89ce50e-1350-11df-a1f1-0026b9348838",
+                    "label": "No"
                   }
                 ]
               }
-            ]
-          }
-        ]
-      }
-    ],
-    "availableIntents": [
-      {
-        "intent": "*",
-        "display": "ObsGroup Test Form"
-      }
-    ],
-    "processor": "EncounterFormProcessor",
-    "uuid": "8f713e0e-94a0-3c57-9024-69520933802a",
-    "referencedForms": [],
-    "encounterType": "7e54cd64-f9c3-11eb-8e6a-57478ce139b0",
-    "encounter": "Obs Group Test",
-    "allowUnspecifiedAll": true
-  }
-  
+            }
+          ]
+        },
+        {
+          "label": "Groups with Hide logic",
+          "questions": [
+            {
+              "type": "obsGroup",
+              "label": "Dependents Group",
+              "id": "dependentGroup",
+              "questionOptions": {
+                "concept": "3665d0ef-3718-47b2-9091-8b685bda412d",
+                "rendering": "group"
+              },
+              "questions": [
+                {
+                  "label": "Dependent Type",
+                  "id": "dependentType",
+                  "type": "obs",
+                  "questionOptions": {
+                    "rendering": "radio",
+                    "concept": "a89e3f94-1350-11df-a1f1-0026b9348838",
+                    "answers": [
+                      {
+                        "concept": "6daff4ce-bce7-41f5-9141-17e694155180",
+                        "label": "Child"
+                      },
+                      {
+                        "concept": "a89ce50e-1350-11df-a1f1-0026b9348838",
+                        "label": "Spouse"
+                      }
+                    ]
+                  },
+                  "hide": {
+                    "hideWhenExpression": "hasDependents !== 'a89ce50e-1350-11df-a1f1-0026b9348839'"
+                  }
+                },
+                {
+                  "label": "Dependent Name",
+                  "id": "dependentName",
+                  "type": "obs",
+                  "questionOptions": {
+                    "rendering": "text",
+                    "concept": "a8a06fc6-1350-11df-a1f1-0026b9348838"
+                  },
+                  "hide": {
+                    "hideWhenExpression": "isEmpty(dependentType)"
+                  }
+                },
+                {
+                  "label": "Dependent Age",
+                  "id": "dependentAge",
+                  "type": "obs",
+                  "questionOptions": {
+                    "rendering": "number",
+                    "concept": "a8a06fc6-1350-11df-a1f1-0026b9348839"
+                  },
+                  "hide": {
+                    "hideWhenExpression": "dependentType !== '6daff4ce-bce7-41f5-9141-17e694155180'"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "availableIntents": [
+    {
+      "intent": "*",
+      "display": "ObsGroup Test Form"
+    }
+  ],
+  "processor": "EncounterFormProcessor",
+  "uuid": "8f713e0e-94a0-3c57-9024-69520933802a",
+  "referencedForms": [],
+  "encounterType": "7e54cd64-f9c3-11eb-8e6a-57478ce139b0",
+  "encounter": "Obs Group Test",
+  "allowUnspecifiedAll": true
+}

--- a/src/components/group/obs-group.component.tsx
+++ b/src/components/group/obs-group.component.tsx
@@ -9,13 +9,13 @@ import { useTranslation } from 'react-i18next';
 
 export const ObsGroup: React.FC<FormFieldInputProps> = ({ field, ...restProps }) => {
   const { t } = useTranslation();
-  const { formFieldAdapters } = useFormProviderContext();
-  const showLabel = useMemo(() => field.questions?.length > 1, [field]);
+  const { formFieldAdapters, formFields } = useFormProviderContext();
 
   const content = useMemo(
     () =>
       field.questions
-        ?.filter((child) => !child.isHidden)
+        .map((child) => formFields.find((field) => field.id === child.id))
+        .filter((child) => !child.isHidden)
         .map((child, index) => {
           const key = `${child.id}_${index}`;
 
@@ -35,12 +35,12 @@ export const ObsGroup: React.FC<FormFieldInputProps> = ({ field, ...restProps })
             );
           }
         }),
-    [field],
+    [field, formFields],
   );
 
   return (
     <div className={styles.groupContainer}>
-      {showLabel ? (
+      {content.length > 1 ? (
         <FormGroup legendText={t(field.label)} className={styles.boldLegend}>
           {content}
         </FormGroup>

--- a/src/form-engine.test.tsx
+++ b/src/form-engine.test.tsx
@@ -877,6 +877,50 @@ describe('Form engine component', () => {
   });
 
   describe('Obs group', () => {
+    it('should not render empty obs group', async () => {
+      await act(async () => {
+        renderForm(null, obsGroupTestForm);
+      });
+
+      // Check that only one obs group is initially rendered
+      const initialGroups = screen.getAllByRole('group', { name: /My Group|Dependents Group/i });
+      expect(initialGroups.length).toBe(1);
+      const dependentTypeRadios = screen.queryAllByRole('radio', { name: /child|spouse/i });
+      expect(dependentTypeRadios.length).toBe(0);
+
+      // Select "Yes" for having dependents
+      const yesRadio = screen.getByRole('radio', { name: /yes/i });
+      await user.click(yesRadio);
+
+      // Now the dependent type radios should be visible
+      const visibleDependentTypeRadios = screen.getAllByRole('radio', { name: /child|spouse/i });
+      expect(visibleDependentTypeRadios.length).toBe(2);
+
+      // Check that the group label is still hidden since it only has one visible field
+      const dependentsGroupResults = screen.queryAllByRole('group', { name: /Dependents Group/i });
+      expect(dependentsGroupResults.length).toBe(0);
+
+      // Check that dependent name and age are still hidden
+      const hiddenDependentNameInput = screen.queryByRole('textbox', { name: /dependent name/i });
+      const hiddenDependentAgeInput = screen.queryByRole('spinbutton', { name: /dependent age/i });
+      expect(hiddenDependentNameInput).toBeNull();
+      expect(hiddenDependentAgeInput).toBeNull();
+
+      // Select "Child" as dependent type
+      await user.click(visibleDependentTypeRadios[0]);
+
+      // Check the visibility of the group label
+      const dependentsGroup = screen.getAllByRole('group', { name: /Dependents Group/i })[0];
+      expect(dependentsGroup).toBeInTheDocument();
+
+      // Check that dependent name and age are now visible
+      const dependentNameInput = screen.getByRole('textbox', { name: /dependent name/i });
+      const dependentAgeInput = screen.getByRole('spinbutton', { name: /dependent age/i });
+
+      expect(dependentNameInput).toBeInTheDocument();
+      expect(dependentAgeInput).toBeInTheDocument();
+    });
+
     it('should save obs group on form submission', async () => {
       const saveEncounterMock = jest.spyOn(api, 'saveEncounter');
       await act(async () => {


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [X] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR fixes an issue observed in the "Adult HIV Return Visit Form" where labels are floating around without corresponding input controls. 

<img width="602" alt="Screenshot 2024-12-10 at 15 47 37" src="https://github.com/user-attachments/assets/1c206c04-7df4-4548-b0f5-e69bf0b00d95">

This issue specifically affects groups without visible members in the initial render stage. The solution is treating the flattened forms fields state from the context as the source of truth.  


## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
