### PR TITLE
(refactor) Refactor usePatientPrograms hook to use SWR

### DIFF
--- a/src/processors/encounter/encounter-form-processor.ts
+++ b/src/processors/encounter/encounter-form-processor.ts
@@ -1,17 +1,5 @@
-import {
-  type FormField,
-  type FormPage,
-  type FormProcessorContextProps,
-  type FormSchema,
-  type FormSection,
-  type ValueAndDisplay,
-} from '../../types';
-import { usePatientPrograms } from '../../hooks/usePatientPrograms';
 import { useEffect, useState } from 'react';
-import { useEncounter } from '../../hooks/useEncounter';
-import { isEmpty } from '../../validators/form-validator';
-import { type FormContextProps } from '../../provider/form-provider';
-import { FormProcessor } from '../form-processor';
+import { type OpenmrsResource, showSnackbar, translateFrom } from '@openmrs/esm-framework';
 import {
   getMutableSessionProps,
   hydrateRepeatField,
@@ -23,23 +11,32 @@ import {
   savePatientIdentifiers,
   savePatientPrograms,
 } from './encounter-processor-helper';
-import { type OpenmrsResource, showSnackbar, translateFrom } from '@openmrs/esm-framework';
-import { moduleName } from '../../globals';
-import { extractErrorMessagesFromResponse } from '../../utils/error-utils';
-import { getPreviousEncounter, saveEncounter } from '../../api';
-import { useEncounterRole } from '../../hooks/useEncounterRole';
+import {
+  type FormField,
+  type FormPage,
+  type FormProcessorContextProps,
+  type FormSchema,
+  type FormSection,
+  type ValueAndDisplay,
+} from '../../types';
 import { evaluateAsyncExpression, type FormNode } from '../../utils/expression-runner';
-import { hasRendering } from '../../utils/common-utils';
+import { extractErrorMessagesFromResponse } from '../../utils/error-utils';
 import { extractObsValueAndDisplay } from '../../utils/form-helper';
+import { FormProcessor } from '../form-processor';
+import { getPreviousEncounter, saveEncounter } from '../../api';
+import { hasRendering } from '../../utils/common-utils';
+import { isEmpty } from '../../validators/form-validator';
+import { moduleName } from '../../globals';
+import { type FormContextProps } from '../../provider/form-provider';
+import { useEncounter } from '../../hooks/useEncounter';
+import { useEncounterRole } from '../../hooks/useEncounterRole';
+import { usePatientPrograms } from '../../hooks/usePatientPrograms';
 
 function useCustomHooks(context: Partial<FormProcessorContextProps>) {
   const [isLoading, setIsLoading] = useState(true);
   const { encounter, isLoading: isLoadingEncounter } = useEncounter(context.formJson);
   const { encounterRole, isLoading: isLoadingEncounterRole } = useEncounterRole();
-  const { isLoading: isLoadingPatientPrograms, patientPrograms } = usePatientPrograms(
-    context.patient?.id,
-    context.formJson,
-  );
+  const { isLoadingPatientPrograms, patientPrograms } = usePatientPrograms(context.patient?.id, context.formJson);
 
   useEffect(() => {
     setIsLoading(isLoadingPatientPrograms || isLoadingEncounter || isLoadingEncounterRole);

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -165,6 +165,10 @@ export interface PatientProgram extends OpenmrsResource {
   states?: Array<ProgramWorkflowState>;
 }
 
+export interface ProgramsFetchResponse {
+  results: Array<PatientProgram>;
+}
+
 export interface PatientProgramPayload {
   program?: string;
   uuid?: string;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Refactors the usePatientProgram hook to leverage an SWR hook for fetching patient programs. With this, we get:

- Automatic caching and revalidation
- Conditional fetching based on the patientUuid and the `formJson.meta.programs.hasProgramFields` property of the form
- Built-in error and loading states
- Better handling of race conditions

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

What's a good test plan for this, @samuelmale? I've tweaked @CynthiaKamau's sample schema from [this PR](https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/273) and amended to include a truthy `meta.programs.hasProgramFields` value to get the hook to run. I get active enrollments back as evidenced by the console.log in this screenshot:

![CleanShot 2024-12-11 at 2  09 01@2x](https://github.com/user-attachments/assets/6769aa6e-7cc0-4004-b4ed-c7179308bdb8)

Is there a more thorough way to test this?

