### PR TITLE
(fix) Correct regex pattern for 12-hour time validation

### DIFF
--- a/src/components/inputs/date/date.component.tsx
+++ b/src/components/inputs/date/date.component.tsx
@@ -113,7 +113,7 @@ const DateField: React.FC<FormFieldInputProps> = ({ field, value: dateValue, err
                 id={field.id}
                 labelText={timePickerLabel}
                 placeholder="HH:MM"
-                pattern="(1[012]|[1-9]):[0-5][0-9])$"
+                pattern="(1[012]|[1-9]):[0-5][0-9]$"
                 type="time"
                 disabled={field.datePickerFormat === 'timer' ? field.isDisabled : !dateValue ? true : false}
                 invalid={errors.length > 0}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Removes an unnecessary closing parenthesis in the date field's time validation regex pattern.

## Screenshots

### Before

![CleanShot 2024-12-11 at 2  29 34@2x](https://github.com/user-attachments/assets/4d51bc74-be1e-4f05-92c7-4dec787bc9ad)

### After

![CleanShot 2024-12-11 at 2  30 01@2x](https://github.com/user-attachments/assets/d7504f51-6a74-47d0-80b9-58f8fe684db8)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
