### PR TITLE
(chore) Release v3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-form-engine-lib",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "React Form Engine for O3",
   "browser": "dist/openmrs-esm-form-engine-lib.js",
   "main": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "react-webcam": "^7.2.0"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "8.x",
+    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-patient-common-lib": "9.x",
     "dayjs": "1.x",
     "i18next": "23.x",
     "react": "18.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3182,8 +3182,8 @@ __metadata:
     webpack-cli: "npm:^5.1.4"
     webpack-dev-server: "npm:^4.15.2"
   peerDependencies:
-    "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": 8.x
+    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-patient-common-lib": 9.x
     dayjs: 1.x
     i18next: 23.x
     react: 18.x
@@ -3267,17 +3267,17 @@ __metadata:
   linkType: hard
 
 "@openmrs/esm-patient-common-lib@npm:next":
-  version: 8.2.1-pre.6187
-  resolution: "@openmrs/esm-patient-common-lib@npm:8.2.1-pre.6187"
+  version: 9.0.1-pre.6367
+  resolution: "@openmrs/esm-patient-common-lib@npm:9.0.1-pre.6367"
   dependencies:
     "@carbon/react": "npm:^1.12.0"
     lodash-es: "npm:^4.17.21"
     uuid: "npm:^8.3.2"
   peerDependencies:
-    "@openmrs/esm-framework": 5.x
+    "@openmrs/esm-framework": 6.x
     react: 18.x
     single-spa: 6.x
-  checksum: 10/13248ac7c52d5a6a2894ed83019628ffd363d1fbf9df190ea477ab1c4d5bceaf752ee6f56d49cd39233da45b57c2b8209cea884a24de26623b7faf02292e7a48
+  checksum: 10/be24f651eaf4193d0fa948b1f4a066852503675efb646159fa67a11a1bda979b71187d365609a14195f21a4a0aa0a7ce81c2502f80acc69c9b5d4739edceacf8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Cuts a new patch release of React Form Engine, `v3.0.1` with backwards compatible bug fixes and improvements to testing and documentation.

Here's the draft changelog:

### Bug fixes

* (fix) Fix submit button loading state by @denniskigen in https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/439
* (fix) Tweak `calcMonthsOnART` helper logic by @denniskigen in https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/441
* (fix) Translate answer labels by @samuelmale in https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/443
* (fix) Hide empty obs groups by @samuelmale in https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/444
* (fix) Clean up hooks by @denniskigen in https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/445
* (fix) Prevent state updates on unmounted components by @denniskigen in https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/446
* (fix) Correct regex pattern for 12-hour time validation by @denniskigen in https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/448
* (fix) O3-4268: Show number input steppers in the number field by @Muta-Jonathan in https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/449

### Docs

* (docs) Update README by @denniskigen in https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/438

### Housekeeping

* (chore) Bump `@openmrs/esm-framework` by @samuelmale in https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/442
* (chore) Bump `@openmrs/esm-framework` by @pirupius in https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/450
