### PR TITLE
(feat) O3-4201: Enhance Number Question Labels Display Unit and Range (Min/Max) from Concept

### DIFF
--- a/src/hooks/useConcepts.ts
+++ b/src/hooks/useConcepts.ts
@@ -5,7 +5,7 @@ import { type FetchResponse, type OpenmrsResource, openmrsFetch, restBaseUrl } f
 type ConceptFetchResponse = FetchResponse<{ results: Array<OpenmrsResource> }>;
 
 const conceptRepresentation =
-  'custom:(uuid,display,conceptClass:(uuid,display),answers:(uuid,display),conceptMappings:(conceptReferenceTerm:(conceptSource:(name),code)))';
+  'custom:(units,lowAbsolute,hiAbsolute,uuid,display,conceptClass:(uuid,display),answers:(uuid,display),conceptMappings:(conceptReferenceTerm:(conceptSource:(name),code)))';
 
 export function useConcepts(references: Set<string>): {
   concepts: Array<OpenmrsResource> | undefined;

--- a/src/hooks/useFormFieldsMeta.ts
+++ b/src/hooks/useFormFieldsMeta.ts
@@ -11,6 +11,20 @@ export function useFormFieldsMeta(rawFormFields: FormField[], concepts: OpenmrsR
         const matchingConcept = findConceptByReference(field.questionOptions.concept, concepts);
         field.questionOptions.concept = matchingConcept ? matchingConcept.uuid : field.questionOptions.concept;
         field.label = field.label ? field.label : matchingConcept?.display;
+        if(matchingConcept)
+        {
+          if(matchingConcept.units)
+          {
+            field.label = field.label + " (" + matchingConcept.units + ")";
+          }
+          if(matchingConcept.lowAbsolute && matchingConcept.hiAbsolute)
+          {
+            field.label = field.label + " (" + matchingConcept.lowAbsolute + "-" + matchingConcept.hiAbsolute + ")";
+            field.questionOptions.min = matchingConcept.lowAbsolute;
+            field.questionOptions.max = matchingConcept.hiAbsolute;
+          }
+        }
+
         if (
           codedTypes.includes(field.questionOptions.rendering) &&
           !field.questionOptions.answers?.length &&


### PR DESCRIPTION
Add (unit) (min-max) to label, validate input against concept min/max

https://openmrs.atlassian.net/browse/O3-4201

Related: https://openmrs.atlassian.net/browse/O3-4122 

4122 also suggests a warning for values within the absolute range but outside normal or critical range. Looking for suggestions on how to implement that, and how to add a test case for a concept with units and min/max

## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
