### PR TITLE
(fix): Add global property limit handling in useConcepts hook

### DIFF
--- a/src/hooks/useConcepts.ts
+++ b/src/hooks/useConcepts.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import useSWRInfinite from 'swr/infinite';
-import { type FetchResponse, type OpenmrsResource, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import { type FetchResponse, openmrsFetch, type OpenmrsResource, restBaseUrl } from '@openmrs/esm-framework';
 
 type ConceptFetchResponse = FetchResponse<{ results: Array<OpenmrsResource> }>;
 
@@ -28,7 +28,9 @@ export function useConcepts(references: Set<string>): {
     const start = index * chunkSize;
     const end = start + chunkSize;
     const referenceChunk = Array.from(references).slice(start, end);
-    return `${restBaseUrl}/concept?references=${referenceChunk.join(',')}&v=${conceptRepresentation}`;
+    return `${restBaseUrl}/concept?references=${referenceChunk.join(
+      ',',
+    )}&v=${conceptRepresentation}&limit=${chunkSize}`;
   };
 
   const { data, error, isLoading } = useSWRInfinite<ConceptFetchResponse, Error>(getUrl, openmrsFetch, {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The `useConcepts` hook currently has two issues with result limits:

- The chunk size is hardcoded to 100 instead of using the configurable `webservices.rest.maxResultsAbsolute` global property
- API calls are only returning 50 results due to `webservices.rest.maxResultsDefault`, as the limit parameter is not being passed

Fixed by adding the limit parameter to the concept API calls to ensure the full result set is returned.
This accurately reflects the single change made: adding the limit parameter to override the default limit of `webservices.rest.maxResultsDefault` results.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
