### PR TITLE
(fix) O3-3881: Render tooltips for optional multi-select fields

### DIFF
--- a/src/components/inputs/multi-select/multi-select.component.tsx
+++ b/src/components/inputs/multi-select/multi-select.component.tsx
@@ -77,10 +77,6 @@ const MultiSelect: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
     return false;
   }, [sessionMode, field.readonly, field.inlineRendering, layoutType, workspaceLayout]);
 
-  const label = useMemo(() => {
-    return field.isRequired ? <FieldLabel field={field} /> : <span>{t(field.label)}</span>;
-  }, [field.isRequired, field.label, t]);
-
   return sessionMode == 'view' || sessionMode == 'embedded-view' ? (
     <div className={styles.formField}>
       <FieldValueView
@@ -104,7 +100,7 @@ const MultiSelect: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
                 items={selectOptions}
                 initialSelectedItems={initiallySelectedQuestionItems}
                 label={''}
-                titleText={label}
+                titleText={<FieldLabel field={field} />}
                 itemToString={(item) => (item ? item.label : ' ')}
                 disabled={field.isDisabled}
                 invalid={errors.length > 0}
@@ -114,7 +110,10 @@ const MultiSelect: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
                 readOnly={isTrue(field.readonly)}
               />
             ) : (
-              <CheckboxGroup legendText={label} name={field.id} readOnly={isTrue(field.readonly)}>
+              <CheckboxGroup
+                name={field.id}
+                legendText={<FieldLabel field={field} />}
+                readOnly={isTrue(field.readonly)}>
                 {field.questionOptions.answers?.map((value, index) => {
                   return (
                     <Checkbox


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Fixes an issue where tooltips for non-required (optional) multi-select field instances don't work as expected. 

## Screenshots
<!-- Required if you are making UI changes. -->

<img width="655" alt="Screenshot 2025-01-27 at 14 42 25" src="https://github.com/user-attachments/assets/b45525e2-424d-41ca-bb3c-10c36233ac89" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-3881

## Other
<!-- Anything not covered above -->
