### PR TITLE
(fix) O3-4410: Adjust Form Workspace Size & Enhance Form UI

### DIFF
--- a/src/components/inputs/file/file.scss
+++ b/src/components/inputs/file/file.scss
@@ -1,3 +1,5 @@
+@use '@carbon/layout';
+
 .label {
   font-family: IBM Plex Sans;
   font-size: 14px;
@@ -28,10 +30,8 @@
   display: flex;
   align-items: center;
   margin-bottom: 1rem;
-}
-
-.selectorButton {
-  margin-right: 1rem;
+  flex-wrap: wrap;
+  gap: layout.$spacing-05;
 }
 
 .caption {

--- a/src/components/renderer/page/page.renderer.scss
+++ b/src/components/renderer/page/page.renderer.scss
@@ -1,5 +1,6 @@
 @use '@carbon/colors';
 @use '@carbon/type';
+@use '@carbon/layout';
 
 .pageContent:last-child > hr {
   display: none;
@@ -37,6 +38,10 @@
 
 .sectionContainer > div {
   background-color: colors.$gray-10;
+}
+
+.sectionContainer :global(.cds--accordion__content) {
+  padding-right: layout.$spacing-05;
 }
 
 .accordionContainer {

--- a/src/components/sidebar/sidebar.component.tsx
+++ b/src/components/sidebar/sidebar.component.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Button, InlineLoading } from '@carbon/react';
+import { useLayoutType } from '@openmrs/esm-framework';
 import { isPageContentVisible } from '../../utils/form-helper';
 import { useCurrentActivePage } from './useCurrentActivePage';
 import { usePageObserver } from './usePageObserver';
@@ -33,6 +34,11 @@ const Sidebar: React.FC<SidebarProps> = ({
     activePages,
     evaluatedPagesVisibility,
   });
+  const layout = useLayoutType();
+  const responsiveSize = useMemo(() => {
+    const isTablet = layout === 'tablet';
+    return isTablet ? 'lg' : 'sm';
+  }, [layout]);
 
   return (
     <div className={styles.sidebar}>
@@ -51,7 +57,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
       <div className={styles.sideNavActions}>
         {sessionMode !== 'view' && (
-          <Button className={styles.saveButton} disabled={isFormSubmitting} type="submit">
+          <Button className={styles.saveButton} disabled={isFormSubmitting} type="submit" size={responsiveSize}>
             {isFormSubmitting ? (
               <InlineLoading description={t('submitting', 'Submitting') + '...'} />
             ) : (
@@ -68,7 +74,8 @@ const Sidebar: React.FC<SidebarProps> = ({
             onCancel?.();
             handleClose?.();
             hideFormCollapseToggle();
-          }}>
+          }}
+          size={responsiveSize}>
           {sessionMode === 'view' ? t('close', 'Close') : t('cancel', 'Cancel')}
         </Button>
       </div>
@@ -86,12 +93,14 @@ interface PageLinkProps {
 function PageLink({ page, currentActivePage, pagesWithErrors, requestPage }: PageLinkProps) {
   const isActive = page.id === currentActivePage;
   const hasError = pagesWithErrors.includes(page.id);
+  const isTablet = useLayoutType() === 'tablet';
   return (
     <div
       className={classNames(styles.pageLink, {
         [styles.activePage]: isActive && !hasError,
         [styles.errorPage]: hasError && !isActive,
         [styles.activeErrorPage]: hasError && isActive,
+        [styles.pageLinkTablet]: isTablet,
       })}>
       <button
         onClick={(e) => {

--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -6,10 +6,14 @@
   border-left: 0.5rem solid colors.$teal-20;
   display: flex;
   align-items: center;
-  height: 3rem;
+  height: layout.$spacing-07;
   padding: 0.25rem 0.5rem;
   background-color: colors.$white;
   margin: 0 0 0.063rem;
+}
+
+.pageLinkTablet {
+  height: layout.$spacing-09;
 }
 
 .pageLink button {

--- a/src/form-engine.component.tsx
+++ b/src/form-engine.component.tsx
@@ -74,21 +74,23 @@ const FormEngine = ({
     return patient && workspaceSize === 'ultra-wide' && mode !== 'embedded-view';
   }, [patient, mode, workspaceSize]);
 
-  const showButtonSet = useMemo(() => {
+  const isFormWorkspaceTooNarrow = useMemo(() => ['narrow'].includes(workspaceSize), [workspaceSize]);
+
+  const showBottomButtonSet = useMemo(() => {
     if (mode === 'embedded-view' || isLoadingDependencies || hasMultiplePages === null) {
       return false;
     }
 
-    return ['narrow', 'wider'].includes(workspaceSize) || !hasMultiplePages;
-  }, [mode, workspaceSize, isLoadingDependencies, hasMultiplePages]);
+    return isFormWorkspaceTooNarrow || !hasMultiplePages;
+  }, [mode, isFormWorkspaceTooNarrow, isLoadingDependencies, hasMultiplePages]);
 
   const showSidebar = useMemo(() => {
     if (mode === 'embedded-view' || isLoadingDependencies || hasMultiplePages === null) {
       return false;
     }
 
-    return ['extra-wide', 'ultra-wide'].includes(workspaceSize) && hasMultiplePages;
-  }, [workspaceSize, isLoadingDependencies, hasMultiplePages]);
+    return !isFormWorkspaceTooNarrow && hasMultiplePages;
+  }, [isFormWorkspaceTooNarrow, isLoadingDependencies, hasMultiplePages]);
 
   useEffect(() => {
     reportError(formError, t('errorLoadingFormSchema', 'Error loading form schema'));
@@ -165,7 +167,7 @@ const FormEngine = ({
                     setIsLoadingFormDependencies={setIsLoadingDependencies}
                   />
                 </div>
-                {showButtonSet && (
+                {showBottomButtonSet && (
                   <ButtonSet className={styles.minifiedButtons}>
                     <Button
                       kind="secondary"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
The forms workspace should be rendered in a `wider` [workspace size](https://github.com/openmrs/openmrs-esm-core/blob/f8f53c0a13696cebcab34d0f5311819d6d6ec46f/packages/framework/esm-extensions/src/workspaces.ts#L50). The following changes are made so that the form renders in a proper manner.

1. The sidebar should be hidden for `narrow` workspace size
2. The sidebar links and buttons should have a `sm` size for desktop view
3. The file uploader buttons expand through the form space. The buttons should wrap accordingly.
4. The accordion by default has a `padding-right` of 2.5rem, which takes up the space necessary for rendering form content.

## Screenshots
### Comparision of before and after scenarios.

https://github.com/user-attachments/assets/18ab2468-ced9-45a4-b3ee-3d1df5359b7b


## Related Issue
https://openmrs.atlassian.net/browse/O3-4410

## Other
<!-- Anything not covered above -->
