### PR TITLE
(fix) O3-4474: Form "Cancel" button shouldn't have a red background on hover

### DIFF
--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -30,6 +30,7 @@
   word-wrap: break-word;
   margin: 0 0 0.063rem;
   color: colors.$gray-100;
+
   :hover {
     cursor: pointer;
   }
@@ -103,12 +104,5 @@
 
   &:global(.cds--inline-loading) {
     min-height: layout.$spacing-05;
-  }
-}
-
-.closeButton {
-  @extend .button;
-  &:hover {
-    background-color: colors.$red-60 !important;
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR addresses ticket O3-4474, which highlights an issue where the Cancel button in the React Form Engine sidebar uses a red hover background. The button should follow the Carbon Button component's tertiary variant styling and display the default hover color defined by $button-tertiary-hover.

Changes include:
- Removing the custom hover style that forces a red background on the Cancel button.

- Allowing the default Carbon hover behavior to apply, which resolves the color inconsistency.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/user-attachments/assets/c3d971f1-decc-4515-99e2-bb302edca6c8




## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4474

## Other
<!-- Anything not covered above -->
