### PR TITLE
(fix) Switches to form-engine-app namespace for form translations

### DIFF
--- a/src/hooks/useFormJson.ts
+++ b/src/hooks/useFormJson.ts
@@ -4,7 +4,7 @@ import { isTrue } from '../utils/boolean-utils';
 import { applyFormIntent } from '../utils/forms-loader';
 import { fetchOpenMRSForm, fetchClobData } from '../api';
 import { getRegisteredFormSchemaTransformers } from '../registry/registry';
-import { moduleName } from '../globals';
+import { formEngineAppName } from '../globals';
 
 export function useFormJson(formUuid: string, rawFormJson: any, encounterUuid: string, formSessionIntent: string) {
   const [formJson, setFormJson] = useState<FormSchema>(null);
@@ -16,7 +16,7 @@ export function useFormJson(formUuid: string, rawFormJson: any, encounterUuid: s
     const setFormJsonWithTranslations = (formJson: FormSchema) => {
       if (formJson?.translations) {
         const language = window.i18next.language;
-        window.i18next.addResourceBundle(language, moduleName, formJson.translations, true, true);
+        window.i18next.addResourceBundle(language, formEngineAppName, formJson.translations, true, true);
       }
       setFormJson(formJson);
     };

--- a/src/post-submission-actions/program-enrollment-action.ts
+++ b/src/post-submission-actions/program-enrollment-action.ts
@@ -2,14 +2,14 @@ import dayjs from 'dayjs';
 import { showSnackbar, translateFrom } from '@openmrs/esm-framework';
 import { getPatientEnrolledPrograms, saveProgramEnrollment } from '../api';
 import { type PostSubmissionAction, type PatientProgramPayload } from '../types';
-import { moduleName } from '../globals';
+import { formEngineAppName } from '../globals';
 import { extractErrorMessagesFromResponse } from '../utils/error-utils';
 
 export const ProgramEnrollmentSubmissionAction: PostSubmissionAction = {
   applyAction: async function ({ patient, encounters, sessionMode }, config) {
     const encounter = encounters[0];
     const encounterLocation = encounter.location['uuid'];
-    const translateFn = (key, defaultValue?) => translateFrom(moduleName, key, defaultValue);
+    const translateFn = (key, defaultValue?) => translateFrom(formEngineAppName, key, defaultValue);
     const programUuid = config.programUuid;
 
     if (sessionMode === 'view') {

--- a/src/processors/encounter/encounter-form-processor.ts
+++ b/src/processors/encounter/encounter-form-processor.ts
@@ -26,7 +26,7 @@ import { FormProcessor } from '../form-processor';
 import { getPreviousEncounter, saveEncounter } from '../../api';
 import { hasRendering } from '../../utils/common-utils';
 import { isEmpty } from '../../validators/form-validator';
-import { moduleName } from '../../globals';
+import { formEngineAppName } from '../../globals';
 import { type FormContextProps } from '../../provider/form-provider';
 import { useEncounter } from '../../hooks/useEncounter';
 import { useEncounterRole } from '../../hooks/useEncounterRole';
@@ -110,7 +110,7 @@ export class EncounterFormProcessor extends FormProcessor {
 
   async processSubmission(context: FormContextProps, abortController: AbortController) {
     const { encounterRole, encounterProvider, encounterDate, encounterLocation } = getMutableSessionProps(context);
-    const translateFn = (key, defaultValue?) => translateFrom(moduleName, key, defaultValue);
+    const translateFn = (key, defaultValue?) => translateFrom(formEngineAppName, key, defaultValue);
     const patientIdentifiers = preparePatientIdentifiers(context.formFields, encounterLocation);
     const encounter = prepareEncounter(context, encounterDate, encounterRole, encounterProvider, encounterLocation);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Replace occurrences of form-engine-lib namespace in favor of form-engine-app to handle form translations 

## Screenshots

<img width="1728" alt="Screenshot 2025-02-25 at 12 03 50" src="https://github.com/user-attachments/assets/1d1ad4ae-71ec-4649-9353-aa3f6efd15eb" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
