### PR TITLE
(feat) Extract translations from processor files

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "coverage": "yarn test --coverage",
     "analyze": "webpack --mode=production --env.analyze=true",
     "prepare": "husky install",
-    "extract-translations": "i18next 'src/**/*.component.tsx' --config './tools/i18next-parser.config.js'"
+    "extract-translations": "i18next 'src/**/*.component.tsx' 'src/**/*.ts' --config './tools/i18next-parser.config.js'"
   },
   "browserslist": [
     "extends browserslist-config-openmrs"

--- a/src/post-submission-actions/program-enrollment-action.ts
+++ b/src/post-submission-actions/program-enrollment-action.ts
@@ -4,12 +4,14 @@ import { getPatientEnrolledPrograms, saveProgramEnrollment } from '../api';
 import { type PostSubmissionAction, type PatientProgramPayload } from '../types';
 import { formEngineAppName } from '../globals';
 import { extractErrorMessagesFromResponse } from '../utils/error-utils';
+import { TOptions } from 'i18next';
 
 export const ProgramEnrollmentSubmissionAction: PostSubmissionAction = {
   applyAction: async function ({ patient, encounters, sessionMode }, config) {
     const encounter = encounters[0];
     const encounterLocation = encounter.location['uuid'];
-    const translateFn = (key, defaultValue?) => translateFrom(formEngineAppName, key, defaultValue);
+    const t = (key: string, defaultValue: string, options?: Omit<TOptions, 'ns' | 'defaultValue'>) =>
+      translateFrom(formEngineAppName, key, defaultValue, options);
     const programUuid = config.programUuid;
 
     if (sessionMode === 'view') {
@@ -49,8 +51,8 @@ export const ProgramEnrollmentSubmissionAction: PostSubmissionAction = {
         };
       } else {
         showSnackbar({
-          title: translateFn('enrollmentDiscontinuationNotAllowed', 'Enrollment discontinuation not allowed'),
-          subtitle: translateFn('cannotDiscontinueEnrollment', 'Cannot discontinue an enrollment that does not exist'),
+          title: t('enrollmentDiscontinuationNotAllowed', 'Enrollment discontinuation not allowed'),
+          subtitle: t('cannotDiscontinueEnrollment', 'Cannot discontinue an enrollment that does not exist'),
           kind: 'error',
           isLowContrast: false,
         });
@@ -63,8 +65,8 @@ export const ProgramEnrollmentSubmissionAction: PostSubmissionAction = {
         // The patient is already enrolled in the program and there is no completion date provided.
         if (sessionMode === 'enter') {
           showSnackbar({
-            title: translateFn('enrollmentNotAllowed', 'Enrollment not allowed'),
-            subtitle: translateFn(
+            title: t('enrollmentNotAllowed', 'Enrollment not allowed'),
+            subtitle: t(
               'alreadyEnrolledDescription',
               'This patient is already enrolled in the selected program and cannot be enrolled again.',
             ),
@@ -77,8 +79,8 @@ export const ProgramEnrollmentSubmissionAction: PostSubmissionAction = {
         // The enrollment has already been completed
         if (sessionMode === 'enter') {
           showSnackbar({
-            title: translateFn('enrollmentAlreadyDiscontinued', 'Enrollment already discontinued'),
-            subtitle: translateFn(
+            title: t('enrollmentAlreadyDiscontinued', 'Enrollment already discontinued'),
+            subtitle: t(
               'alreadyDiscontinuedDescription',
               'This patient is already enrolled in the selected program and has already been discontinued.',
             ),
@@ -93,13 +95,13 @@ export const ProgramEnrollmentSubmissionAction: PostSubmissionAction = {
       (response) => {
         showSnackbar({
           kind: 'success',
-          title: getSnackTitle(translateFn, response),
+          title: getSnackTitle(t, response),
           isLowContrast: true,
         });
       },
       (err) => {
         showSnackbar({
-          title: translateFn('errorSavingEnrollment', 'Error saving enrollment'),
+          title: t('errorSavingEnrollment', 'Error saving enrollment'),
           subtitle: extractErrorMessagesFromResponse(err).join(', '),
           kind: 'error',
           isLowContrast: false,
@@ -109,14 +111,11 @@ export const ProgramEnrollmentSubmissionAction: PostSubmissionAction = {
   },
 };
 
-function getSnackTitle(translateFn, response) {
+function getSnackTitle(t, response) {
   if (response.data.dateCompleted) {
-    return translateFn(
-      'enrollmentDiscontinued',
-      "The patient's program enrollment has been successfully discontinued.",
-    );
+    return t('enrollmentDiscontinued', "The patient's program enrollment has been successfully discontinued.");
   }
-  return translateFn('enrolledToProgram', 'The patient has been successfully enrolled in the program.');
+  return t('enrolledToProgram', 'The patient has been successfully enrolled in the program.');
 }
 
 function updateTimeToNow(dateString) {

--- a/src/processors/encounter/encounter-form-processor.ts
+++ b/src/processors/encounter/encounter-form-processor.ts
@@ -31,6 +31,7 @@ import { type FormContextProps } from '../../provider/form-provider';
 import { useEncounter } from '../../hooks/useEncounter';
 import { useEncounterRole } from '../../hooks/useEncounterRole';
 import { usePatientPrograms } from '../../hooks/usePatientPrograms';
+import { TOptions } from 'i18next';
 
 function useCustomHooks(context: Partial<FormProcessorContextProps>) {
   const [isLoading, setIsLoading] = useState(true);
@@ -110,7 +111,8 @@ export class EncounterFormProcessor extends FormProcessor {
 
   async processSubmission(context: FormContextProps, abortController: AbortController) {
     const { encounterRole, encounterProvider, encounterDate, encounterLocation } = getMutableSessionProps(context);
-    const translateFn = (key, defaultValue?) => translateFrom(formEngineAppName, key, defaultValue);
+    const t = (key: string, defaultValue: string, options?: Omit<TOptions, 'ns' | 'defaultValue'>) =>
+      translateFrom(formEngineAppName, key, defaultValue, options);
     const patientIdentifiers = preparePatientIdentifiers(context.formFields, encounterLocation);
     const encounter = prepareEncounter(context, encounterDate, encounterRole, encounterProvider, encounterLocation);
 
@@ -119,7 +121,7 @@ export class EncounterFormProcessor extends FormProcessor {
       await Promise.all(savePatientIdentifiers(context.patient, patientIdentifiers));
       if (patientIdentifiers?.length) {
         showSnackbar({
-          title: translateFn('patientIdentifiersSaved', 'Patient identifier(s) saved successfully'),
+          title: t('patientIdentifiersSaved', 'Patient identifier(s) saved successfully'),
           kind: 'success',
           isLowContrast: true,
         });
@@ -127,7 +129,7 @@ export class EncounterFormProcessor extends FormProcessor {
     } catch (error) {
       const errorMessages = extractErrorMessagesFromResponse(error);
       return Promise.reject({
-        title: translateFn('errorSavingPatientIdentifiers', 'Error saving patient identifiers'),
+        title: t('errorSavingPatientIdentifiers', 'Error saving patient identifiers'),
         description: errorMessages.join(', '),
         kind: 'error',
         critical: true,
@@ -144,7 +146,7 @@ export class EncounterFormProcessor extends FormProcessor {
       const savedPrograms = await await savePatientPrograms(programs);
       if (savedPrograms?.length) {
         showSnackbar({
-          title: translateFn('patientProgramsSaved', 'Patient program(s) saved successfully'),
+          title: t('patientProgramsSaved', 'Patient program(s) saved successfully'),
           kind: 'success',
           isLowContrast: true,
         });
@@ -152,7 +154,7 @@ export class EncounterFormProcessor extends FormProcessor {
     } catch (error) {
       const errorMessages = extractErrorMessagesFromResponse(error);
       return Promise.reject({
-        title: translateFn('errorSavingPatientPrograms', 'Error saving patient program(s)'),
+        title: t('errorSavingPatientPrograms', 'Error saving patient program(s)'),
         description: errorMessages.join(', '),
         kind: 'error',
         critical: true,
@@ -166,7 +168,7 @@ export class EncounterFormProcessor extends FormProcessor {
       const savedDiagnoses = savedEncounter.diagnoses.map((diagnosis) => diagnosis.display);
       if (savedOrders.length) {
         showSnackbar({
-          title: translateFn('ordersSaved', 'Order(s) saved successfully'),
+          title: t('ordersSaved', 'Order(s) saved successfully'),
           subtitle: savedOrders.join(', '),
           kind: 'success',
           isLowContrast: true,
@@ -175,7 +177,7 @@ export class EncounterFormProcessor extends FormProcessor {
       // handle diagnoses
       if (savedDiagnoses.length) {
         showSnackbar({
-          title: translateFn('diagnosisSaved', 'Diagnosis(es) saved successfully'),
+          title: t('diagnosisSaved', 'Diagnosis(es) saved successfully'),
           subtitle: savedDiagnoses.join(', '),
           kind: 'success',
           isLowContrast: true,
@@ -188,7 +190,7 @@ export class EncounterFormProcessor extends FormProcessor {
         );
         if (attachmentsResponse?.length) {
           showSnackbar({
-            title: translateFn('attachmentsSaved', 'Attachment(s) saved successfully'),
+            title: t('attachmentsSaved', 'Attachment(s) saved successfully'),
             kind: 'success',
             isLowContrast: true,
           });
@@ -196,7 +198,7 @@ export class EncounterFormProcessor extends FormProcessor {
       } catch (error) {
         const errorMessages = extractErrorMessagesFromResponse(error);
         return Promise.reject({
-          title: translateFn('errorSavingAttachments', 'Error saving attachment(s)'),
+          title: t('errorSavingAttachments', 'Error saving attachment(s)'),
           description: errorMessages.join(', '),
           kind: 'error',
           critical: true,
@@ -206,7 +208,7 @@ export class EncounterFormProcessor extends FormProcessor {
     } catch (error) {
       const errorMessages = extractErrorMessagesFromResponse(error);
       return Promise.reject({
-        title: translateFn('errorSavingEncounter', 'Error saving encounter'),
+        title: t('errorSavingEncounter', 'Error saving encounter'),
         description: errorMessages.join(', '),
         kind: 'error',
         critical: true,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
The processor files have multiple `showSnackbar` calls with translation strings, but these are not extracted by the `i18next-parser`. The i18next parser looks for `t(key, defaultValue, options)`pattern, and our `translateFrom` function can be modified in the following manner to match the i18next parser format.

```
const t = (key, value, options) => translateFrom(moduleName, key, value, options)
```

## Screenshots
Before the parser extracted only 39 keys.

<img width="1172" alt="image" src="https://github.com/user-attachments/assets/ff1b62c2-dc3f-454a-ac93-63ab997865bf" />


Now, the parser extracts 59 keys (addition of 20 keys)

<img width="1174" alt="image" src="https://github.com/user-attachments/assets/f409d554-ef41-46e7-8d5a-4b6b17956fbb" />


## Related Issue
None

## Other
<!-- Anything not covered above -->
