### PR TITLE
(fix) Consistently interpolate `conceptUuid` URL parameter in `SelectConceptAnswersDatasource`

### DIFF
--- a/src/datasources/select-concept-answers-datasource.ts
+++ b/src/datasources/select-concept-answers-datasource.ts
@@ -1,15 +1,25 @@
-import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import { openmrsFetch, OpenmrsResource, restBaseUrl } from '@openmrs/esm-framework';
 import { BaseOpenMRSDataSource } from './data-source';
 
 export class SelectConceptAnswersDatasource extends BaseOpenMRSDataSource {
   constructor() {
-    super(`${restBaseUrl}/concept/conceptUuid?v=custom:(uuid,setMembers:(uuid,display),answers:(uuid,display))`);
+    super(
+      `${restBaseUrl}/concept/:conceptUuid?v=custom:(uuid,display,setMembers:(uuid,display),answers:(uuid,display))`,
+    );
+  }
+
+  fetchSingleItem(uuid: string): Promise<OpenmrsResource | null> {
+    return openmrsFetch(this.buildUrl(uuid)).then(({ data }) => data);
   }
 
   fetchData(searchTerm: string, config?: Record<string, any>): Promise<any[]> {
-    const apiUrl = this.url.replace('conceptUuid', config.referencedValue || config.concept);
+    const apiUrl = this.buildUrl(config.referencedValue || config.concept);
     return openmrsFetch(apiUrl).then(({ data }) => {
       return data['setMembers'].length ? data['setMembers'] : data['answers'];
     });
+  }
+
+  private buildUrl(conceptUuid: string): string {
+    return this.url.replace(':conceptUuid', conceptUuid);
   }
 }


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Replaces string literal replacement with proper URL parameter interpolation for `conceptUuid`. This fixes [an issue](https://openmrs.slack.com/archives/C02UNMKFH8V/p1741477460891589) where forms fail to render correctly in edit mode due to improper URL parameter handling. The previous implementation caused concept data to be fetched incorrectly.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:

https://github.com/user-attachments/assets/35b1ac4b-e235-4fc1-bca0-d806e546b4d5

After:

https://github.com/user-attachments/assets/2228a75f-a266-4b05-b933-61bca42f50ea

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
