### PR TITLE
(fix) Change the alignment of the tooltip to right

### DIFF
--- a/src/components/inputs/tooltip/tooltip.component.tsx
+++ b/src/components/inputs/tooltip/tooltip.component.tsx
@@ -12,7 +12,7 @@ interface TooltipProps {
 const Tooltip: React.FC<TooltipProps> = ({ field }) => {
   const { t } = useTranslation();
   return (
-    <CarbonTooltip align="top" label={t(field.questionInfo)} description={t(field.questionInfo)}>
+    <CarbonTooltip align="right" label={t(field.questionInfo)} description={t(field.questionInfo)}>
       <button className={styles.tooltip} type="button" data-testid={field.id}>
         <Information />
       </button>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR changes the tooltip's alignment from the top to the right since the tooltip on the top gets cropped by the accordion's boundaries.

## Screenshots
### Before
<img width="688" alt="image" src="https://github.com/user-attachments/assets/4fb4a1c2-0528-4541-9b15-97689b91c3ef" />


### After
<img width="768" alt="image" src="https://github.com/user-attachments/assets/0370fa4a-6562-4093-86d2-de96c578465d" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
