### PR TITLE
(fix) O3-4546 Prevent form from freezing when an obsGroup child has the same ID as its parent by displaying an error message.

### DIFF
--- a/src/components/group/obs-group.component.tsx
+++ b/src/components/group/obs-group.component.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import classNames from 'classnames';
 import { type FormFieldInputProps } from '../../types';
 import styles from './obs-group.scss';
-import { FormFieldRenderer, isGroupField } from '../renderer/field/form-field-renderer.component';
+import { ErrorFallback, FormFieldRenderer, isGroupField } from '../renderer/field/form-field-renderer.component';
 import { useFormProviderContext } from '../../provider/form-provider';
 import { FormGroup } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
@@ -18,6 +18,11 @@ export const ObsGroup: React.FC<FormFieldInputProps> = ({ field, ...restProps })
         .filter((child) => !child.isHidden)
         .map((child, index) => {
           const key = `${child.id}_${index}`;
+          if (child.id === field.id) {
+            return (
+              <ErrorFallback error={new Error('ObsGroup child has same id as parent question')}/>
+            );
+          }
 
           if (child.type === 'obsGroup' && isGroupField(child.questionOptions.rendering)) {
             return (

--- a/src/components/renderer/field/form-field-renderer.component.tsx
+++ b/src/components/renderer/field/form-field-renderer.component.tsx
@@ -215,7 +215,7 @@ export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: Form
   );
 };
 
-function ErrorFallback({ error }) {
+export function ErrorFallback({ error }) {
   const { t } = useTranslation();
   return (
     <ToastNotification


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- Added error handling to prevent app from becoming unresponsive when an obsGroup child shares the same ID as its parent.
- Stop multiple recursion which makes form-builder app stop responding.
- Displays a meaningful error message in Preview.

## Screenshots
Before:
[Screencast from 2025-03-19 11-39-37.webm](https://github.com/user-attachments/assets/c887136d-5152-4930-98f1-21f80fcd6341)

After:
[Screencast from 2025-03-19 19-20-06.webm](https://github.com/user-attachments/assets/4e170388-5f5a-4766-8d7f-5c11a58e2312)


## Related Issue
https://openmrs.atlassian.net/browse/O3-4546

## Other
<!-- Anything not covered above -->
