### PR TITLE
(fix) Use the correct value arg for the Number Input

### DIFF
--- a/src/components/inputs/number/number.component.tsx
+++ b/src/components/inputs/number/number.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Layer, NumberInput } from '@carbon/react';
 import classNames from 'classnames';
 import { isTrue } from '../../../utils/boolean-utils';
@@ -13,7 +13,6 @@ import { isEmpty } from '../../../validators/form-validator';
 
 const NumberField: React.FC<FormFieldInputProps> = ({ field, value, errors, warnings, setFieldValue }) => {
   const { t } = useTranslation();
-  const [lastBlurredValue, setLastBlurredValue] = useState(value);
   const { layoutType, sessionMode, workspaceLayout } = useFormProviderContext();
 
   const numberValue = useMemo(() => {
@@ -22,13 +21,6 @@ const NumberField: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
     }
     return value ?? '';
   }, [value]);
-
-  const onBlur = (event) => {
-    event.preventDefault();
-    if (lastBlurredValue != value) {
-      setLastBlurredValue(value);
-    }
-  };
 
   const handleChange = useCallback(
     (event, { value }) => {
@@ -67,11 +59,9 @@ const NumberField: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
           name={field.id}
           value={numberValue}
           onChange={handleChange}
-          onBlur={onBlur}
           allowEmpty={true}
           size="lg"
           hideSteppers={field.hideSteppers ?? false}
-          onWheel={(e) => e.target.blur()}
           disabled={field.isDisabled}
           readOnly={isTrue(field.readonly)}
           className={classNames(styles.controlWidthConstrained, styles.boldedLabel)}

--- a/src/components/inputs/number/number.component.tsx
+++ b/src/components/inputs/number/number.component.tsx
@@ -31,8 +31,8 @@ const NumberField: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
   };
 
   const handleChange = useCallback(
-    (event) => {
-      const parsedValue = isEmpty(event.target.value) ? undefined : Number(event.target.value);
+    (event, { value }) => {
+      const parsedValue = isEmpty(value) ? undefined : Number(value);
       setFieldValue(isNaN(parsedValue) ? undefined : parsedValue);
     },
     [setFieldValue],


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR fixes setting the Number Input's value. It uses the second argument of Carbon's `NumberInput`, which returns the updated value, including the changes made by the controls.

## Screenshots


https://github.com/user-attachments/assets/19f3afb0-e625-4fc5-9e88-315351d66b63


## Related Issue
None

## Other
<!-- Anything not covered above -->
