### PR TITLE
(fix) Add translation wrapper to markdown and multi-select answers

### DIFF
--- a/src/components/inputs/markdown/markdown.component.tsx
+++ b/src/components/inputs/markdown/markdown.component.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import MarkdownWrapper from './markdown-wrapper.component';
 import { type FormFieldInputProps } from '../../../types';
 
 const Markdown: React.FC<FormFieldInputProps> = ({ field }) => {
-  return !field.isHidden && <MarkdownWrapper markdown={field.value} />;
+  const { t } = useTranslation();
+  return !field.isHidden && <MarkdownWrapper markdown={t(field.value)} />;
 };
 export default Markdown;

--- a/src/components/inputs/markdown/markdown.component.tsx
+++ b/src/components/inputs/markdown/markdown.component.tsx
@@ -5,6 +5,8 @@ import { type FormFieldInputProps } from '../../../types';
 
 const Markdown: React.FC<FormFieldInputProps> = ({ field }) => {
   const { t } = useTranslation();
-  return !field.isHidden && <MarkdownWrapper markdown={t(field.value)} />;
+  return !field.isHidden && <MarkdownWrapper
+    markdown={t(field.value, { defaultValue: field.value, interpolation: { escapeValue: false } })}
+  />;
 };
 export default Markdown;

--- a/src/components/inputs/multi-select/multi-select.component.tsx
+++ b/src/components/inputs/multi-select/multi-select.component.tsx
@@ -143,7 +143,7 @@ const MultiSelect: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
               <div className={styles.tagContainer}>
                 {formFieldAdapters[field.type]?.getDisplayValue(field, value)?.map((displayValue, index) => (
                   <Tag key={index} type="cool-gray">
-                    {displayValue}
+                    {t(displayValue)}
                   </Tag>
                 ))}
               </div>

--- a/src/components/inputs/multi-select/multi-select.component.tsx
+++ b/src/components/inputs/multi-select/multi-select.component.tsx
@@ -101,7 +101,7 @@ const MultiSelect: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
                 initialSelectedItems={initiallySelectedQuestionItems}
                 label={''}
                 titleText={<FieldLabel field={field} />}
-                itemToString={(item) => (item ? item.label : ' ')}
+                itemToString={(item) => (item ? t(item.label) : ' ')}
                 disabled={field.isDisabled}
                 invalid={errors.length > 0}
                 invalidText={errors[0]?.message}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Adds missing translation wrapper to markdown value and selected answers on multi-select fields

## Screenshots
**Before:**
Markdown:
<img width="535" alt="Screenshot 2025-04-02 at 17 07 24" src="https://github.com/user-attachments/assets/31672118-7e6b-4fd8-98e8-ce922b00d6d8" />


Multi-select answers:
<img width="535" alt="Screenshot 2025-04-02 at 17 08 52" src="https://github.com/user-attachments/assets/ae4db0a5-7f7a-466f-8316-d6df287f0ccb" />


**After:**

Markdown:
<img width="747" alt="Screenshot 2025-04-02 at 17 05 31" src="https://github.com/user-attachments/assets/587024cb-cee3-4532-a48d-13215988f54d" />

Multi-select answers:
<img width="542" alt="Screenshot 2025-04-02 at 17 04 24" src="https://github.com/user-attachments/assets/6ac66334-9048-4c53-914a-b497a5a15cee" />



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
