### PR TITLE
(fix) Undefined `min` and `max` values for the number inputs

### DIFF
--- a/src/components/inputs/number/number.component.tsx
+++ b/src/components/inputs/number/number.component.tsx
@@ -22,12 +22,17 @@ const NumberField: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
     return value ?? '';
   }, [value]);
 
+  const getNumericValue = useCallback(
+    (value: string | number) => (typeof value === 'undefined' || isNaN(Number(value)) ? undefined : Number(value)),
+    [],
+  );
+
   const handleChange = useCallback(
     (event, { value }) => {
-      const parsedValue = isEmpty(value) ? undefined : Number(value);
+      const parsedValue = getNumericValue(value);
       setFieldValue(isNaN(parsedValue) ? undefined : parsedValue);
     },
-    [setFieldValue],
+    [setFieldValue, getNumericValue],
   );
 
   const isInline = useMemo(() => {
@@ -36,6 +41,9 @@ const NumberField: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
     }
     return false;
   }, [sessionMode, field.readonly, field.inlineRendering, layoutType, workspaceLayout]);
+
+  const max = getNumericValue(field.questionOptions.max);
+  const min = getNumericValue(field.questionOptions.min);
 
   return sessionMode == 'view' || sessionMode == 'embedded-view' ? (
     <div className={styles.formField}>
@@ -54,8 +62,8 @@ const NumberField: React.FC<FormFieldInputProps> = ({ field, value, errors, warn
           invalid={errors.length > 0}
           invalidText={errors[0]?.message}
           label={<FieldLabel field={field} />}
-          max={Number(field.questionOptions.max) || undefined}
-          min={Number(field.questionOptions.min) || undefined}
+          max={max}
+          min={min}
           name={field.id}
           value={numberValue}
           onChange={handleChange}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
The Carbon Input by default restricts the value change by the steppers between min and max values. But this restriction isn't working for the form engine. I went to the [Carbon NumberInput code for the min and max restriction](https://github.com/carbon-design-system/carbon/blob/0ce91ed5ad791ce04fa7878f2d3cffe7496267c3/packages/react/src/components/NumberInput/NumberInput.tsx#L376) and realized that the min and max value we might be sending is actually `undefined`, and if any value among the min/max values is `undefined`, the restriction doesn't work.

I went to the code and realized that the final value for the min and max `value` is: `Number(field.questionOptions.min) || undefined`. Now, if the `field.questionOptions.min = 0`, the value passed isn't 0, but `undefined`. The `||` check must be replaced by `??`. I have added a better check for getting the correct value.

## Screenshots
### Before


https://github.com/user-attachments/assets/3ffec393-d7b3-4750-8880-f13685b9237b


### After

https://github.com/user-attachments/assets/908ed244-0329-4e24-a5c2-2f04d1b80ab0


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
