### PR TITLE
(chore) Adjust update-openms-deps.yml to run once a week

### DIFF
--- a/.github/workflows/update-openmrs-deps.yml
+++ b/.github/workflows/update-openmrs-deps.yml
@@ -2,7 +2,7 @@ on:
   workflow_dispatch:
   schedule:
     # every hour
-    - cron: '30 * * * *'
+    - cron: '30 0 * * 1'
 
 name: 'Check for OpenMRS Dependency Updates'
 

--- a/.github/workflows/update-openmrs-deps.yml
+++ b/.github/workflows/update-openmrs-deps.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
   schedule:
-    # every hour
+    # Once every week on Monday at 00:30
     - cron: '30 0 * * 1'
 
 name: 'Check for OpenMRS Dependency Updates'


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This cron has been running every 30mins and has been adding a bunch of commits even if nothing much has been changing on the FE lib side of things. This change adjusts it to run once a week (Monday at midnight)

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
