### PR TITLE
(fix) Remove unnecessary extra wrapper from field label

### DIFF
--- a/src/components/field-label/field-label.component.tsx
+++ b/src/components/field-label/field-label.component.tsx
@@ -27,34 +27,28 @@ const TooltipWrapper: React.FC<{ field: FormField; children: React.ReactNode }> 
   );
 };
 
-const FieldLabelContent: React.FC<FieldLabelProps> = ({ field, customLabel }) => {
+const FieldLabel: React.FC<FieldLabelProps> = ({ field, customLabel }) => {
   const { t } = useTranslation();
   const hasTooltip = Boolean(field.questionInfo);
   const labelText = customLabel || t(field.label);
   return (
-    <div className={styles.questionLabel} data-testid={`${field.id}-label`}>
-      <span>{labelText}</span>
-      {field.isRequired && (
-        <span title={t('required', 'Required')} className={styles.required}>
-          *
-        </span>
-      )}
-      {hasTooltip && (
-        <Information
-          size={20}
-          aria-hidden="true"
-          className={styles.tooltipIcon}
-          data-testid={`${field.id}-information-icon`}
-        />
-      )}
-    </div>
-  );
-};
-
-const FieldLabel: React.FC<FieldLabelProps> = (props) => {
-  return (
-    <TooltipWrapper field={props.field}>
-      <FieldLabelContent {...props} />
+    <TooltipWrapper field={field}>
+      <div className={styles.questionLabel} data-testid={`${field.id}-label`}>
+        <span>{labelText}</span>
+        {field.isRequired && (
+          <span title={t('required', 'Required')} className={styles.required}>
+            *
+          </span>
+        )}
+        {hasTooltip && (
+          <Information
+            size={20}
+            aria-hidden="true"
+            className={styles.tooltipIcon}
+            data-testid={`${field.id}-information-icon`}
+          />
+        )}
+      </div>
     </TooltipWrapper>
   );
 };

--- a/src/form-engine.test.tsx
+++ b/src/form-engine.test.tsx
@@ -253,7 +253,7 @@ describe('Form engine component', () => {
         renderForm(null, sampleFieldsForm);
       });
 
-      screen.findByRole('textbox', { name: /text question/i });
+      screen.findByLabelText(/text question/i);
 
       const textFieldTooltip = screen.getByTestId('id_text-label');
       expect(textFieldTooltip).toBeInTheDocument();
@@ -359,7 +359,7 @@ describe('Form engine component', () => {
       const requiredAsterisks = screen.getAllByText('*');
       expect(requiredAsterisks).toHaveLength(2);
 
-      const inputFields = screen.getAllByRole('textbox', { name: /Text question/i });
+      const inputFields = screen.getAllByLabelText(/Text question/i);
       expect(inputFields).toHaveLength(2);
 
       inputFields.forEach((inputField) => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
The field label tooltip wasn't being displayed so this PR removes extra wrapper that was initially added.

## Screenshots

**BEFORE**

Tooltip wouldn't display on hover

<img width="777" alt="Screenshot 2025-05-22 at 15 57 59" src="https://github.com/user-attachments/assets/e75e8b65-9396-4ffa-9df3-0546b4fbefb4" />

**AFTER** 

<img width="790" alt="Screenshot 2025-05-22 at 15 56 56" src="https://github.com/user-attachments/assets/65ae53f2-f570-487c-beb0-45b7a646625e" />



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
