### PR TITLE
(feat) O3-4928 Hide interactive elements when embedded-view mode applied

### DIFF
--- a/src/components/inputs/workspace-launcher/workspace-launcher.component.tsx
+++ b/src/components/inputs/workspace-launcher/workspace-launcher.component.tsx
@@ -3,9 +3,11 @@ import { useTranslation } from 'react-i18next';
 import { showSnackbar } from '@openmrs/esm-framework';
 import { useLaunchWorkspaceRequiringVisit } from '@openmrs/esm-patient-common-lib';
 import { Button } from '@carbon/react';
+
 import { useFormProviderContext } from '../../../provider/form-provider';
 import { type FormFieldInputProps } from '../../../types';
 import { isTrue } from '../../../utils/boolean-utils';
+import { isViewMode } from '../../../utils/common-utils';
 import styles from './workspace-launcher.scss';
 
 const WorkspaceLauncher: React.FC<FormFieldInputProps> = ({ field }) => {
@@ -25,7 +27,7 @@ const WorkspaceLauncher: React.FC<FormFieldInputProps> = ({ field }) => {
     launchWorkspace();
   };
 
-  if (field.isHidden || sessionMode === 'embedded-view') {
+  if (field.isHidden || isViewMode(sessionMode)) {
     return null;
   }
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- When the form is rendered in `embedded view` mode, it is intended for display-only purposes. Interactive elements that navigate the user or launch new workflows should be disabled/removed.

## Screenshots
Before: 
<img width="954" height="216" alt="image" src="https://github.com/user-attachments/assets/a0891219-e751-4930-a1da-04d3d10480b6" />
After: 
<img width="965" height="136" alt="image" src="https://github.com/user-attachments/assets/6edb43b3-bf8f-48b5-adc6-ba2c763597d4" />

## Ticket
https://openmrs.atlassian.net/browse/O3-4928

