### PR TITLE
(fix) Initialize encounter date on backend if not defined within form fields

### DIFF
--- a/src/processors/encounter/encounter-processor-helper.ts
+++ b/src/processors/encounter/encounter-processor-helper.ts
@@ -160,23 +160,13 @@ export function saveAttachments(fields: FormField[], encounter: OpenmrsEncounter
 }
 
 export function getMutableSessionProps(context: FormContextProps) {
-  const {
-    formFields,
-    location,
-    currentProvider,
-    sessionDate,
-    customDependencies,
-    domainObjectValue: encounter,
-  } = context;
+  const { formFields, location, currentProvider, customDependencies, domainObjectValue: encounter } = context;
   const { defaultEncounterRole } = customDependencies;
   const encounterRole =
     formFields.find((field) => field.type === 'encounterRole')?.meta.submission?.newValue || defaultEncounterRole?.uuid;
   const encounterProvider =
     formFields.find((field) => field.type === 'encounterProvider')?.meta.submission?.newValue || currentProvider.uuid;
-  const encounterDate =
-    formFields.find((field) => field.type === 'encounterDatetime')?.meta.submission?.newValue ||
-    encounter?.encounterDatetime ||
-    sessionDate;
+  const encounterDate = formFields.find((field) => field.type === 'encounterDatetime')?.meta.submission?.newValue;
   const encounterLocation =
     formFields.find((field) => field.type === 'encounterLocation')?.meta.submission?.newValue ||
     encounter?.location?.uuid ||


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR updates the encounter submission logic to ensure `encounter.encounterDatetime` is initialized by the backend unless the form explicitly defines a field bound to `encounter.encounterDatetime`.

See related fix for the AFE: https://github.com/openmrs/openmrs-ngx-formentry/pull/131

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
