### PR TITLE
(feat): Enable Toggling The Patient Banner in non-workspaces Zones

### DIFF
--- a/src/form-engine.component.tsx
+++ b/src/form-engine.component.tsx
@@ -34,6 +34,7 @@ interface FormEngineProps {
   handleConfirmQuestionDeletion?: (question: Readonly<FormField>) => Promise<void>;
   markFormAsDirty?: (isDirty: boolean) => void;
   hideControls?: boolean;
+  hidePatientBanner?: boolean;
   preFilledQuestions?: PreFilledQuestions;
 }
 
@@ -51,6 +52,7 @@ const FormEngine = ({
   handleConfirmQuestionDeletion,
   markFormAsDirty,
   hideControls = false,
+  hidePatientBanner = false,
   preFilledQuestions,
 }: FormEngineProps) => {
   const { t } = useTranslation();
@@ -75,8 +77,9 @@ const FormEngine = ({
   } = useFormJson(formUUID, formJson, encounterUUID, formSessionIntent, preFilledQuestions);
 
   const showPatientBanner = useMemo(() => {
+    if (hidePatientBanner) return false;
     return patient && workspaceSize === 'ultra-wide' && mode !== 'embedded-view';
-  }, [patient, mode, workspaceSize]);
+  }, [patient, mode, workspaceSize, hidePatientBanner]);
 
   const isFormWorkspaceTooNarrow = useMemo(() => ['narrow'].includes(workspaceSize), [workspaceSize]);
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currently, the patient banner visibility can only be toggled in workspace zones. However, there are other non-workspace zones, such as the FDE, where we also want this flexibility. This PR introduces a new `hidePatientBanner` prop, which defaults to `false`, allowing the banner to be hidden in these additional contexts.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
