### PR TITLE
(feat) O3-4959: Support hiding unanswered questions in embedded forms via config

### DIFF
--- a/src/components/renderer/field/fieldRenderUtils.test.ts
+++ b/src/components/renderer/field/fieldRenderUtils.test.ts
@@ -5,8 +5,21 @@ describe('shouldRenderField', () => {
     const sessionMode = 'embedded-view';
     const isTransient = true;
     const isEmpty = true;
+    const hideUnansweredQuestionsInReadonlyForms = false;
 
-    const result = shouldRenderField(sessionMode, isTransient, isEmpty);
+    const result = shouldRenderField(sessionMode, isTransient, isEmpty, hideUnansweredQuestionsInReadonlyForms);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false for non-transient empty fields when hideUnansweredQuestionsInReadonlyForms is true in embedded-view mode', () => {
+    const sessionMode = 'embedded-view';
+    const isTransient = false;
+    const isEmpty = true;
+    const hideUnansweredQuestionsInReadonlyForms = true;
+
+    const result = shouldRenderField(sessionMode, isTransient, isEmpty, hideUnansweredQuestionsInReadonlyForms);
+
     expect(result).toBe(false);
   });
 
@@ -14,17 +27,32 @@ describe('shouldRenderField', () => {
     const sessionMode = 'embedded-view';
     const isTransient = true;
     const isEmpty = false;
+    const hideUnansweredQuestionsInReadonlyForms = true;
 
-    const result = shouldRenderField(sessionMode, isTransient, isEmpty);
+    const result = shouldRenderField(sessionMode, isTransient, isEmpty, hideUnansweredQuestionsInReadonlyForms);
+
     expect(result).toBe(true);
   });
 
-  it('should return true for non-transient fields in embedded-view mode', () => {
+  it('should return true for non-transient empty fields when hideUnansweredQuestionsInReadonlyForms is false in embedded-view mode', () => {
     const sessionMode = 'embedded-view';
     const isTransient = false;
     const isEmpty = true;
+    const hideUnansweredQuestionsInReadonlyForms = false;
 
-    const result = shouldRenderField(sessionMode, isTransient, isEmpty);
+    const result = shouldRenderField(sessionMode, isTransient, isEmpty, hideUnansweredQuestionsInReadonlyForms);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true for non-empty fields in embedded-view mode regardless of flags', () => {
+    const sessionMode = 'embedded-view';
+    const isTransient = false;
+    const isEmpty = false;
+    const hideUnansweredQuestionsInReadonlyForms = true;
+
+    const result = shouldRenderField(sessionMode, isTransient, isEmpty, hideUnansweredQuestionsInReadonlyForms);
+
     expect(result).toBe(true);
   });
 
@@ -32,8 +60,10 @@ describe('shouldRenderField', () => {
     const sessionMode = 'edit';
     const isTransient = true;
     const isEmpty = true;
+    const hideUnansweredQuestionsInReadonlyForms = true;
 
-    const result = shouldRenderField(sessionMode, isTransient, isEmpty);
+    const result = shouldRenderField(sessionMode, isTransient, isEmpty, hideUnansweredQuestionsInReadonlyForms);
+
     expect(result).toBe(true);
   });
 });

--- a/src/components/renderer/field/fieldRenderUtils.ts
+++ b/src/components/renderer/field/fieldRenderUtils.ts
@@ -2,9 +2,15 @@ import { type SessionMode } from '../../../types';
 
 /**
  * @name shouldRenderField
- * @description Determines if a field should be rendered based on the session mode, whether it is transient, and if it is empty.
- * - A field will not be rendered in 'embedded-view' mode if it is transient and has no value.
+ * @description Returns true if a field should be rendered.
+ * A field is hidden in 'embedded-view' mode when it is empty
+ * and either transient or `hideUnansweredQuestionsInReadonlyForms` is enabled.
  */
-export function shouldRenderField(sessionMode: SessionMode, isTransient: boolean, isEmpty: boolean): boolean {
-  return !(sessionMode === 'embedded-view' && isTransient && isEmpty);
+export function shouldRenderField(
+  sessionMode: SessionMode,
+  isTransient: boolean,
+  isEmptyValue: boolean,
+  hideUnansweredQuestionsInReadonlyForms: boolean,
+): boolean {
+  return !(sessionMode === 'embedded-view' && isEmptyValue && (isTransient || hideUnansweredQuestionsInReadonlyForms));
 }

--- a/src/components/renderer/field/form-field-renderer.component.tsx
+++ b/src/components/renderer/field/form-field-renderer.component.tsx
@@ -3,6 +3,7 @@ import { ToastNotification } from '@carbon/react';
 import { Controller, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { ErrorBoundary } from 'react-error-boundary';
+import { useConfig } from '@openmrs/esm-framework';
 import {
   type FormField,
   type FormFieldInputProps,
@@ -38,6 +39,9 @@ export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: Form
   const [warnings, setWarnings] = useState<ValidationResult[]>([]);
   const [historicalValue, setHistoricalValue] = useState<ValueAndDisplay>(null);
   const context = useFormProviderContext();
+  const { hideUnansweredQuestionsInReadonlyForms } = useConfig({
+    externalModuleName: '@openmrs/esm-form-engine-app',
+  });
 
   const {
     methods: { control, getValues, getFieldState },
@@ -174,9 +178,16 @@ export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: Form
     );
   }
 
-  // If the field is transient and has no value, we do not render it in embedded view mode.
-  // This is to prevent transient fields from being displayed in the form when they are not necessarily needed.
-  if (!shouldRenderField(sessionMode, !!field.questionOptions.isTransient, isEmpty(fieldValue))) {
+  // In 'embedded-view' mode, empty fields are hidden if they are transient
+  // or if the config flag `hideUnansweredQuestionsInReadonlyForms` is enabled.
+  if (
+    !shouldRenderField(
+      sessionMode,
+      !!field.questionOptions.isTransient,
+      isEmpty(fieldValue),
+      hideUnansweredQuestionsInReadonlyForms,
+    )
+  ) {
     return null;
   }
 

--- a/src/form-engine.test.tsx
+++ b/src/form-engine.test.tsx
@@ -1076,9 +1076,12 @@ describe('Form engine component', () => {
       await user.click(addButton);
 
       expect(screen.getByRole('button', { name: /Remove/i })).toBeInTheDocument();
-      expect(screen.getAllByRole('radio', { name: /^male$/i }).length).toEqual(2);
-      expect(screen.getAllByRole('radio', { name: /^female$/i }).length).toEqual(2);
-      expect(screen.getAllByRole('textbox', { name: /date of birth/i }).length).toEqual(2);
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('radio', { name: /^male$/i })).toHaveLength(2);
+        expect(screen.getAllByRole('radio', { name: /female/i })).toHaveLength(2);
+        expect(screen.getAllByRole('textbox', { name: /date of birth/i })).toHaveLength(2);
+      });
     });
 
     it('should test deletion of a group', async () => {

--- a/src/hooks/useEvaluateFormFieldExpressions.ts
+++ b/src/hooks/useEvaluateFormFieldExpressions.ts
@@ -15,7 +15,7 @@ export const useEvaluateFormFieldExpressions = (
   const { formFields, patient, sessionMode } = factoryContext;
   const [evaluatedFormJson, setEvaluatedFormJson] = useState(factoryContext.formJson);
   const [evaluatedPagesVisibility, setEvaluatedPagesVisibility] = useState(false);
-  const { hideUnansweredQuestionsInReadonlyForms } = useConfig();
+  const { hideUnansweredQuestionsInReadonlyForms } = useConfig({ externalModuleName: '@openmrs/esm-form-engine-app' });
 
   const evaluatedFields = useMemo(() => {
     return formFields?.map((field) => {

--- a/src/hooks/useEvaluateFormFieldExpressions.ts
+++ b/src/hooks/useEvaluateFormFieldExpressions.ts
@@ -6,7 +6,6 @@ import { isTrue } from '../utils/boolean-utils';
 import { isEmpty } from '../validators/form-validator';
 import { type QuestionAnswerOption } from '../types/schema';
 import { updateFormSectionReferences } from '../utils/common-utils';
-import { useConfig } from '@openmrs/esm-framework';
 
 export const useEvaluateFormFieldExpressions = (
   formValues: Record<string, any>,
@@ -15,7 +14,6 @@ export const useEvaluateFormFieldExpressions = (
   const { formFields, patient, sessionMode } = factoryContext;
   const [evaluatedFormJson, setEvaluatedFormJson] = useState(factoryContext.formJson);
   const [evaluatedPagesVisibility, setEvaluatedPagesVisibility] = useState(false);
-  const { hideUnansweredQuestionsInReadonlyForms } = useConfig({ externalModuleName: '@openmrs/esm-form-engine-app' });
 
   const evaluatedFields = useMemo(() => {
     return formFields?.map((field) => {
@@ -40,8 +38,7 @@ export const useEvaluateFormFieldExpressions = (
           });
         }
       } else {
-        field.isHidden =
-          hideUnansweredQuestionsInReadonlyForms && sessionMode === 'embedded-view' && !hasAnswer(field, formValues);
+        field.isHidden = false;
       }
       // evaluate required
       if (typeof field.required === 'object' && field.required.type === 'conditionalRequired') {
@@ -151,9 +148,4 @@ export const useEvaluateFormFieldExpressions = (
 
 function isNotBooleanString(str: string) {
   return str !== 'true' && str !== 'false';
-}
-
-function hasAnswer(field: any, formValues: Record<string, any>): boolean {
-  const value = formValues[field.id];
-  return !isEmpty(value);
 }

--- a/src/hooks/useEvaluateFormFieldExpressions.ts
+++ b/src/hooks/useEvaluateFormFieldExpressions.ts
@@ -6,6 +6,7 @@ import { isTrue } from '../utils/boolean-utils';
 import { isEmpty } from '../validators/form-validator';
 import { type QuestionAnswerOption } from '../types/schema';
 import { updateFormSectionReferences } from '../utils/common-utils';
+import { useConfig } from '@openmrs/esm-framework';
 
 export const useEvaluateFormFieldExpressions = (
   formValues: Record<string, any>,
@@ -14,6 +15,7 @@ export const useEvaluateFormFieldExpressions = (
   const { formFields, patient, sessionMode } = factoryContext;
   const [evaluatedFormJson, setEvaluatedFormJson] = useState(factoryContext.formJson);
   const [evaluatedPagesVisibility, setEvaluatedPagesVisibility] = useState(false);
+  const { hideUnansweredQuestionsInReadonlyForms } = useConfig();
 
   const evaluatedFields = useMemo(() => {
     return formFields?.map((field) => {
@@ -38,7 +40,8 @@ export const useEvaluateFormFieldExpressions = (
           });
         }
       } else {
-        field.isHidden = false;
+        field.isHidden =
+          hideUnansweredQuestionsInReadonlyForms && sessionMode === 'embedded-view' && !hasAnswer(field, formValues);
       }
       // evaluate required
       if (typeof field.required === 'object' && field.required.type === 'conditionalRequired') {
@@ -148,4 +151,9 @@ export const useEvaluateFormFieldExpressions = (
 
 function isNotBooleanString(str: string) {
   return str !== 'true' && str !== 'false';
+}
+
+function hasAnswer(field: any, formValues: Record<string, any>): boolean {
+  const value = formValues[field.id];
+  return !isEmpty(value);
 }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Use the `hideUnansweredQuestionsInReadonlyForms` config flag to hide unanswered questions in read‑only O3 forms (embedded view), unless an explicit hide expression is defined.

## Related PRs
https://github.com/openmrs/openmrs-esm-patient-chart/pull/2693

## Related Issue
https://openmrs.atlassian.net/browse/O3-4959
