### PR TITLE
(fix): Add fallback for hideUnansweredQuestionsInReadonlyForms config

### DIFF
--- a/src/components/renderer/field/form-field-renderer.component.tsx
+++ b/src/components/renderer/field/form-field-renderer.component.tsx
@@ -53,7 +53,6 @@ export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: Form
       'Could not load external module config, using default value for hideUnansweredQuestionsInReadonlyForms:',
       error,
     );
-    hideUnansweredQuestionsInReadonlyForms = false;
   }
 
   const {

--- a/src/components/renderer/field/form-field-renderer.component.tsx
+++ b/src/components/renderer/field/form-field-renderer.component.tsx
@@ -50,7 +50,7 @@ export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: Form
   } catch (error) {
     // If external module config is not available, use default value
     console.warn(
-      'Failed to load @openmrs/esm-form engine-app config - using hideUnansweredQuestionsInReadonlyForms=false (empty fields will be visible in readonly mode): '
+      'Failed to load @openmrs/esm-form engine-app config - using hideUnansweredQuestionsInReadonlyForms=false (empty fields will be visible in readonly mode): ',
       error,
     );
   }

--- a/src/components/renderer/field/form-field-renderer.component.tsx
+++ b/src/components/renderer/field/form-field-renderer.component.tsx
@@ -39,9 +39,22 @@ export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: Form
   const [warnings, setWarnings] = useState<ValidationResult[]>([]);
   const [historicalValue, setHistoricalValue] = useState<ValueAndDisplay>(null);
   const context = useFormProviderContext();
-  const { hideUnansweredQuestionsInReadonlyForms } = useConfig({
-    externalModuleName: '@openmrs/esm-form-engine-app',
-  });
+
+  // Try to get config from external module, fallback to default if not available
+  let hideUnansweredQuestionsInReadonlyForms = false;
+  try {
+    const config = useConfig({
+      externalModuleName: '@openmrs/esm-form-engine-app',
+    });
+    hideUnansweredQuestionsInReadonlyForms = config?.hideUnansweredQuestionsInReadonlyForms ?? false;
+  } catch (error) {
+    // If external module config is not available, use default value
+    console.warn(
+      'Could not load external module config, using default value for hideUnansweredQuestionsInReadonlyForms:',
+      error,
+    );
+    hideUnansweredQuestionsInReadonlyForms = false;
+  }
 
   const {
     methods: { control, getValues, getFieldState },

--- a/src/components/renderer/field/form-field-renderer.component.tsx
+++ b/src/components/renderer/field/form-field-renderer.component.tsx
@@ -50,7 +50,7 @@ export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: Form
   } catch (error) {
     // If external module config is not available, use default value
     console.warn(
-      'Could not load external module config, using default value for hideUnansweredQuestionsInReadonlyForms:',
+      'Failed to load @openmrs/esm-form engine-app config - using hideUnansweredQuestionsInReadonlyForms=false (empty fields will be visible in readonly mode): '
       error,
     );
   }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds a try-catch block around the external module configuration retrieval to prevent the component from crashing when the configuration from `@openmrs/esm-form-engine-app` module cannot be loaded. This is needed for cases where like the form-builder where the `@openmrs/esm-form-engine-app` is not used.  The component now gracefully falls back to a default value (false) for hideUnansweredQuestionsInReadonlyForms and logs a warning when configuration loading fails.

## Screenshots
<!-- Required if you are making UI changes. -->
After:

https://github.com/user-attachments/assets/cafbf652-df19-4b95-919c-3c190d7a6a3d

Before:


https://github.com/user-attachments/assets/41a07bbc-7df4-4dc9-b067-b7f1b1c45012



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
