### PR TITLE
O3-5037: render 0 values instead of showing (Blank)

### DIFF
--- a/src/components/value/view/field-value-view.component.tsx
+++ b/src/components/value/view/field-value-view.component.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isEmpty } from '../../../validators/form-validator';
 import LabelField from '../../label/label.component';
 import { ValueDisplay, ValueEmpty } from '../value.component';
 import styles from './field-value-view.scss';
@@ -17,13 +18,15 @@ const FieldValueView: React.FC<FieldValueViewProps> = ({ label, conceptName, val
         <div className={styles.inlineFlexColumn}>
           <LabelField value={label} tooltipText={conceptName} />
         </div>
-        <div className={styles.inlineFlexColumn}>{value ? <ValueDisplay value={value} /> : <ValueEmpty />}</div>
+        <div className={styles.inlineFlexColumn}>
+          {isEmpty(value) ? <ValueEmpty /> : <ValueDisplay value={value} />}
+        </div>
       </div>
     ) : (
       <div className={styles.readonly}>
         <div className={styles.formField}>
           <LabelField value={label} tooltipText={conceptName} />
-          <div className={styles.value}>{value ? <ValueDisplay value={value} /> : <ValueEmpty />}</div>
+          <div className={styles.value}>{isEmpty(value) ? <ValueEmpty /> : <ValueDisplay value={value} />}</div>
         </div>
       </div>
     )}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Fields with the value **0** were incorrectly displayed as **(Blank)** because of the current rendering logic. This change ensures that **0** is shown as a valid value, while only truly empty values (null, undefined, empty string, empty array) continue to appear as (Blank).

## Screenshots
Now:
<img width="393" height="111" alt="image" src="https://github.com/user-attachments/assets/96e0aa64-3128-45bf-abe9-28628613e095" />
Before (value 0 rendered as a Blank):
<img width="393" height="111" alt="image" src="https://github.com/user-attachments/assets/1863d740-c0ef-456b-8453-32290377e6f1" />


## Related Issue
https://openmrs.atlassian.net/browse/O3-5037
