### PR TITLE
fix(form-renderer): clear validation errors on input change (O3-4628)

### DIFF
--- a/src/components/renderer/form/form-renderer.component.tsx
+++ b/src/components/renderer/form/form-renderer.component.tsx
@@ -31,10 +31,13 @@ export const FormRenderer = ({
   const { registerForm, setIsFormDirty, workspaceLayout, isFormExpanded } = useFormFactory();
   const methods = useForm({
     defaultValues: initialValues,
+    mode: 'onChange',
+    reValidateMode: 'onChange',
+    criteriaMode: 'all',
   });
 
   const {
-    formState: { isDirty },
+    formState: { isDirty, errors },
   } = methods;
 
   const [{ formFields, invalidFields, formJson, deletedFields }, dispatch] = useReducer(formStateReducer, {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR fixes the issue where validation errors in input fields do not disappear when users type to correct their input in forms rendered by the OpenMRS Form Engine.

The root cause was that the React Hook Form hook (useForm) was configured without validation modes that enable real-time error clearing. This change updates the useForm hook configuration in form-renderer.component.tsx to set:
- mode: 'onChange'
- reValidateMode: 'onChange'
- criteriaMode: 'all'

This configuration allows validation errors to be reset immediately as users modify input fields, improving form UX without changing core validation logic or processors.

## Related Issue
Fixes [O3-4628](https://openmrs.atlassian.net/browse/O3-4628)