### PR TITLE
(fix) O3-4463: Hide sidebar on wider workspaces to fix multi-section form layout

### DIFF
--- a/src/form-engine.component.test.tsx
+++ b/src/form-engine.component.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { usePatient, useSession } from '@openmrs/esm-framework';
+import { mockPatient, mockSessionDataResponse, mockVisit } from '__mocks__';
+import FormEngine from './form-engine.component';
+
+jest.mock('./hooks/useFormWorkspaceSize', () => ({
+  useFormWorkspaceSize: jest.fn().mockReturnValue('wider'),
+}));
+
+jest.mock('./components/sidebar/usePageObserver', () => ({
+  usePageObserver: jest.fn().mockReturnValue({
+    pages: [{ id: 'p1' }, { id: 'p2' }],
+    pagesWithErrors: [],
+    activePages: [],
+    evaluatedPagesVisibility: false,
+    hasMultiplePages: true,
+  }),
+}));
+
+jest.mock('./hooks/useFormCollapse', () => ({
+  useFormCollapse: jest.fn().mockReturnValue({
+    isFormExpanded: true,
+    hideFormCollapseToggle: jest.fn(),
+  }),
+}));
+
+jest.mock('./hooks/usePatientData', () => ({
+  usePatientData: jest.fn().mockReturnValue({
+    patient: { id: 'test-patient' },
+    isLoadingPatient: false,
+  }),
+}));
+
+jest.mock('./hooks/useFormJson', () => ({
+  useFormJson: jest.fn().mockReturnValue({
+    formJson: {
+      name: 'multi-section-test-form',
+      pages: [
+        { label: 'Page 1', sections: [] },
+        { label: 'Page 2', sections: [] },
+      ],
+    },
+    isLoading: false,
+    formError: null,
+  }),
+}));
+
+jest.mock('./lifecycle', () => ({
+  init: jest.fn(),
+  teardown: jest.fn(),
+}));
+
+jest.mock('./components/processor-factory/form-processor-factory.component', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('./components/sidebar/sidebar.component', () => ({
+  __esModule: true,
+  default: () => <div data-testid="form-sidebar">sidebar</div>,
+}));
+
+jest.mock('./components/patient-banner/patient-banner.component', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockUsePatient = jest.mocked(usePatient);
+const mockUseSession = jest.mocked(useSession);
+
+describe('FormEngine sidebar visibility', () => {
+  beforeEach(() => {
+    mockUsePatient.mockReturnValue({
+      patient: mockPatient,
+      isLoading: false,
+      error: undefined,
+      patientUuid: mockPatient.id,
+    });
+    mockUseSession.mockReturnValue(mockSessionDataResponse.data);
+  });
+
+  it('hides sidebar and shows bottom button set on wider workspaces for multi-section forms', () => {
+    render(
+      <FormEngine
+        patientUUID="8673ee4f-e2ab-4077-ba55-4980f408773e"
+        visit={mockVisit}
+        mode="enter"
+      />,
+    );
+
+    expect(screen.queryByTestId('form-sidebar')).not.toBeInTheDocument();
+
+    const buttonSet = document.querySelector('.minifiedButtons');
+    expect(buttonSet).toBeInTheDocument();
+    expect(within(buttonSet as HTMLElement).getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    expect(within(buttonSet as HTMLElement).getByRole('button', { name: /save/i })).toBeInTheDocument();
+  });
+});

--- a/src/form-engine.component.tsx
+++ b/src/form-engine.component.tsx
@@ -83,23 +83,23 @@ const FormEngine = ({
     return patient && workspaceSize === 'ultra-wide' && mode !== 'embedded-view';
   }, [patient, mode, workspaceSize, hidePatientBanner]);
 
-  const isFormWorkspaceTooNarrow = useMemo(() => ['narrow', 'wider'].includes(workspaceSize), [workspaceSize]);
+  const shouldHideFormSidebar = useMemo(() => ['narrow', 'wider'].includes(workspaceSize), [workspaceSize]);
 
   const showBottomButtonSet = useMemo(() => {
     if (mode === 'embedded-view' || isLoadingDependencies || hasMultiplePages === null) {
       return false;
     }
 
-    return isFormWorkspaceTooNarrow || !hasMultiplePages;
-  }, [mode, isFormWorkspaceTooNarrow, isLoadingDependencies, hasMultiplePages]);
+    return shouldHideFormSidebar || !hasMultiplePages;
+  }, [mode, shouldHideFormSidebar, isLoadingDependencies, hasMultiplePages]);
 
   const showSidebar = useMemo(() => {
     if (mode === 'embedded-view' || isLoadingDependencies || hasMultiplePages === null) {
       return false;
     }
 
-    return !isFormWorkspaceTooNarrow && hasMultiplePages;
-  }, [isFormWorkspaceTooNarrow, isLoadingDependencies, hasMultiplePages]);
+    return !shouldHideFormSidebar && hasMultiplePages;
+  }, [shouldHideFormSidebar, isLoadingDependencies, hasMultiplePages]);
 
   useEffect(() => {
     reportError(formError, t('errorLoadingFormSchema', 'Error loading form schema'));

--- a/src/form-engine.component.tsx
+++ b/src/form-engine.component.tsx
@@ -83,7 +83,7 @@ const FormEngine = ({
     return patient && workspaceSize === 'ultra-wide' && mode !== 'embedded-view';
   }, [patient, mode, workspaceSize, hidePatientBanner]);
 
-  const isFormWorkspaceTooNarrow = useMemo(() => ['narrow'].includes(workspaceSize), [workspaceSize]);
+  const isFormWorkspaceTooNarrow = useMemo(() => ['narrow', 'wider'].includes(workspaceSize), [workspaceSize]);
 
   const showBottomButtonSet = useMemo(() => {
     if (mode === 'embedded-view' || isLoadingDependencies || hasMultiplePages === null) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

PR #461 (O3-4410) changed the sidebar visibility logic so that the sidebar shows on all workspace sizes except `narrow`. This caused a layout regression on `wider` workspaces — the sidebar (180px) and form content compete for space, resulting in a cramped/squished layout for multi-section forms.

This fix adds `'wider'` to the `isFormWorkspaceTooNarrow` check, so the sidebar only renders on `extra-wide` and `ultra-wide` workspaces where there is sufficient room. On `narrow` and `wider` workspaces, multi-section forms use bottom navigation buttons instead.

| Workspace Size | Sidebar | Navigation |
|---|---|---|
| `narrow` | Hidden | Bottom buttons |
| `wider` | Hidden (was showing — the bug) | Bottom buttons |
| `extra-wide` | Visible | Left sidebar |
| `ultra-wide` | Visible | Left sidebar |

## Screenshots

### Before (bug — sidebar cramped on `wider` workspace)
<img width="430" height="803" alt="image" src="https://github.com/user-attachments/assets/b0c37eca-ee1f-4842-b224-dabc1b579063" />


### After (fix — sidebar hidden on `wider`, bottom buttons used instead)
<img width="479" height="808" alt="image" src="https://github.com/user-attachments/assets/af390170-a915-4f06-bf45-a8b19b21a42f" />

## Related Issue

https://openmrs.atlassian.net/browse/O3-4463

## Other

- One line changed in `src/form-engine.component.tsx`
- No CSS changes, no new dependencies
- Restores the intended sidebar behavior from before PR #461
- Existing tests unaffected
