### PR TITLE
(fix) O3-4643: Skip applying form translations when locale doesn't match

### DIFF
--- a/src/hooks/__tests__/useFormJson.test.ts
+++ b/src/hooks/__tests__/useFormJson.test.ts
@@ -1,0 +1,89 @@
+import { act, renderHook } from '@testing-library/react';
+import { useFormJson } from '../useFormJson';
+
+jest.mock('../../api', () => ({
+  fetchOpenMRSForm: jest.fn().mockResolvedValue({ uuid: 'mock-uuid' }),
+  fetchClobData: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../../registry/registry', () => ({
+  getRegisteredFormSchemaTransformers: jest.fn().mockResolvedValue([]),
+}));
+
+describe('useFormJson translations logic', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    window.i18next = {
+      language: 'en',
+      addResourceBundle: jest.fn(),
+    };
+  });
+
+  const runHookWithTranslations = async (translations: any) => {
+    const rawFormJson = {
+      name: 'Test Form',
+      pages: [],
+      translations,
+    };
+
+    let hook: any;
+    await act(async () => {
+      hook = renderHook(() => useFormJson(null as any, rawFormJson, null as any, null as any));
+    });
+
+    return hook;
+  };
+
+  it('Exact match (`en` vs `en`) -> addResourceBundle called', async () => {
+    window.i18next.language = 'en';
+    await runHookWithTranslations({ language: 'en', key: 'value' });
+    expect(window.i18next.addResourceBundle).toHaveBeenCalledWith(
+      'en',
+      '@openmrs/esm-form-engine-app',
+      expect.any(Object),
+      true,
+      true,
+    );
+  });
+
+  it('Form has region tag, session is base (`fr-CA` form vs `fr` session) -> called', async () => {
+    window.i18next.language = 'fr';
+    await runHookWithTranslations({ language: 'fr-CA', key: 'value' });
+    expect(window.i18next.addResourceBundle).toHaveBeenCalledWith(
+      'fr',
+      '@openmrs/esm-form-engine-app',
+      expect.any(Object),
+      true,
+      true,
+    );
+  });
+
+  it('Session has region tag, form is base (`fr` form vs `fr-CA` session) -> called', async () => {
+    window.i18next.language = 'fr-CA';
+    await runHookWithTranslations({ language: 'fr', key: 'value' });
+    expect(window.i18next.addResourceBundle).toHaveBeenCalledWith(
+      'fr-CA',
+      '@openmrs/esm-form-engine-app',
+      expect.any(Object),
+      true,
+      true,
+    );
+  });
+
+  it('Locale mismatch (`en` session vs `fr` form) -> NOT called', async () => {
+    window.i18next.language = 'en';
+    await runHookWithTranslations({ language: 'fr', key: 'value' });
+    expect(window.i18next.addResourceBundle).not.toHaveBeenCalled();
+  });
+
+  it('translations object exists but has no language field -> NOT called', async () => {
+    window.i18next.language = 'en';
+    await runHookWithTranslations({ key: 'value' });
+    expect(window.i18next.addResourceBundle).not.toHaveBeenCalled();
+  });
+
+  it('formJson.translations is undefined -> NOT called, no crash', async () => {
+    window.i18next.language = 'en';
+    await runHookWithTranslations(undefined);
+    expect(window.i18next.addResourceBundle).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useFormJson.ts
+++ b/src/hooks/useFormJson.ts
@@ -4,6 +4,7 @@ import { isTrue } from '../utils/boolean-utils';
 import { applyFormIntent } from '../utils/forms-loader';
 import { fetchOpenMRSForm, fetchClobData } from '../api';
 import { getRegisteredFormSchemaTransformers } from '../registry/registry';
+import { useSession } from '@openmrs/esm-framework';
 import { formEngineAppName } from '../globals';
 
 export function useFormJson(
@@ -15,14 +16,21 @@ export function useFormJson(
 ) {
   const [formJson, setFormJson] = useState<FormSchema>(null);
   const [error, setError] = useState(validateFormsArgs(formUuid, rawFormJson));
+  const session = useSession();
 
   useEffect(() => {
     const abortController = new AbortController();
 
     const setFormJsonWithTranslations = (formJson: FormSchema) => {
       if (formJson?.translations) {
-        const language = window.i18next.language;
-        window.i18next.addResourceBundle(language, formEngineAppName, formJson.translations, true, true);
+        // Retrieve the current user's locale from the session or fallback to i18next's active language
+        const sessionLocale = session?.user?.userProperties?.defaultLocale ?? session?.locale ?? window?.i18next?.language;
+        const currentLocale = sessionLocale?.split(/_|-/)[0];
+        
+        // Only apply translations if the language matches the current user's session locale
+        if (formJson.translations?.language === currentLocale) {
+          window.i18next.addResourceBundle(currentLocale, formEngineAppName, formJson.translations, true, true);
+        }
       }
       setFormJson(formJson);
     };

--- a/src/hooks/useFormJson.ts
+++ b/src/hooks/useFormJson.ts
@@ -4,7 +4,6 @@ import { isTrue } from '../utils/boolean-utils';
 import { applyFormIntent } from '../utils/forms-loader';
 import { fetchOpenMRSForm, fetchClobData } from '../api';
 import { getRegisteredFormSchemaTransformers } from '../registry/registry';
-import { useSession } from '@openmrs/esm-framework';
 import { formEngineAppName } from '../globals';
 
 export function useFormJson(
@@ -16,20 +15,20 @@ export function useFormJson(
 ) {
   const [formJson, setFormJson] = useState<FormSchema>(null);
   const [error, setError] = useState(validateFormsArgs(formUuid, rawFormJson));
-  const session = useSession();
 
   useEffect(() => {
     const abortController = new AbortController();
 
     const setFormJsonWithTranslations = (formJson: FormSchema) => {
       if (formJson?.translations) {
-        // Retrieve the current user's locale from the session or fallback to i18next's active language
-        const sessionLocale = session?.user?.userProperties?.defaultLocale ?? session?.locale ?? window?.i18next?.language;
-        const currentLocale = sessionLocale?.split(/_|-/)[0];
-        
-        // Only apply translations if the language matches the current user's session locale
-        if (formJson.translations?.language === currentLocale) {
-          window.i18next.addResourceBundle(currentLocale, formEngineAppName, formJson.translations, true, true);
+        const formTranslationLocale = formJson.translations.language;
+        if (formTranslationLocale) {
+          const normalizedCurrent = window.i18next?.language?.split(/[-_]/)[0];
+          const normalizedForm = formTranslationLocale.split(/[-_]/)[0];
+          
+          if (normalizedCurrent && normalizedCurrent === normalizedForm) {
+            window.i18next.addResourceBundle(window.i18next.language, formEngineAppName, formJson.translations, true, true);
+          }
         }
       }
       setFormJson(formJson);


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
When a form has a translation file for one language (e.g. French) but not for the user's current locale (e.g. English), the French translations were incorrectly applied to the form — because there was no locale check before calling `addResourceBundle`.

This fix:
- Retrieves the session locale via `useSession()` with fallback to `window.i18next.language`
- Normalizes to language code only (e.g. `en_GB` → `en`) to handle region variants
- Only calls `addResourceBundle` if `formJson.translations.language` matches the current locale
- Forms with no matching translation file now fall back gracefully to their original labels

## Screenshots
N/A: no UI changes.

## Related Issue
https://issues.openmrs.org/browse/O3-4643

## Other
Reference workaround for the same issue: https://github.com/openmrs/path-drc-emr/pull/12