### PR TITLE
(fix) Scope concept fallback to parent obsGroup boundaries

### DIFF
--- a/src/adapters/obs-adapter.test.ts
+++ b/src/adapters/obs-adapter.test.ts
@@ -1086,6 +1086,108 @@ describe('findObsByFormField', () => {
     expect(matchedObs.length).toBe(1);
     expect(matchedObs[0]).toBe(obsList[3]);
   });
+
+  it('Should scope concept fallback to the parent obsGroup when field has a groupId', () => {
+    // Scenario: Two repeating obsGroups (e.g. ARV and PrEP) whose child fields share
+    // the same concept. When editing a PrEP-only encounter, the ARV child field should
+    // NOT steal PrEP obs via concept fallback.
+    const strengthConcept = 'shared-strength-concept-uuid';
+
+    const arvStrengthField: FormField = {
+      label: 'ARV Strength',
+      type: 'obs',
+      questionOptions: { rendering: 'select', concept: strengthConcept },
+      id: 'arv_strength',
+      meta: { groupId: 'arvGroup' },
+    };
+
+    const prepStrengthObs = {
+      uuid: 'prep-strength-obs-uuid',
+      concept: { uuid: strengthConcept },
+      formFieldNamespace: 'rfe-forms',
+      formFieldPath: 'rfe-forms-prep_strength',
+    };
+
+    const prepGroupObs = {
+      uuid: 'prep-group-obs-uuid',
+      concept: { uuid: 'prep-group-concept' },
+      formFieldNamespace: 'rfe-forms',
+      formFieldPath: 'rfe-forms-prepGroup',
+      groupMembers: [prepStrengthObs],
+    };
+
+    const flatObs = [prepGroupObs, prepStrengthObs];
+
+    // ARV strength field should NOT match the PrEP strength obs
+    const matched = findObsByFormField(flatObs, [], arvStrengthField);
+    expect(matched.length).toBe(0);
+  });
+
+  it('Should allow concept fallback within the correct parent obsGroup', () => {
+    const strengthConcept = 'shared-strength-concept-uuid';
+
+    const prepStrengthField: FormField = {
+      label: 'PrEP Strength',
+      type: 'obs',
+      questionOptions: { rendering: 'select', concept: strengthConcept },
+      id: 'prep_strength_NEW',
+      meta: { groupId: 'prepGroup' },
+    };
+
+    const prepStrengthObs = {
+      uuid: 'prep-strength-obs-uuid',
+      concept: { uuid: strengthConcept },
+      formFieldNamespace: 'rfe-forms',
+      formFieldPath: 'rfe-forms-prep_strength',
+    };
+
+    const prepGroupObs = {
+      uuid: 'prep-group-obs-uuid',
+      concept: { uuid: 'prep-group-concept' },
+      formFieldNamespace: 'rfe-forms',
+      formFieldPath: 'rfe-forms-prepGroup',
+      groupMembers: [prepStrengthObs],
+    };
+
+    const flatObs = [prepGroupObs, prepStrengthObs];
+
+    // PrEP strength field SHOULD match via concept fallback (correct group)
+    const matched = findObsByFormField(flatObs, [], prepStrengthField);
+    expect(matched.length).toBe(1);
+    expect(matched[0]).toBe(prepStrengthObs);
+  });
+
+  it('Should preserve backward compatibility when parent obsGroup has no formFieldPath', () => {
+    const strengthConcept = 'shared-strength-concept-uuid';
+
+    const childField: FormField = {
+      label: 'Strength',
+      type: 'obs',
+      questionOptions: { rendering: 'select', concept: strengthConcept },
+      id: 'some_strength',
+      meta: { groupId: 'myGroup' },
+    };
+
+    const strengthObs = {
+      uuid: 'strength-obs-uuid',
+      concept: { uuid: strengthConcept },
+      formFieldNamespace: 'rfe-forms',
+      formFieldPath: 'rfe-forms-old_field_id',
+    };
+
+    const groupObs = {
+      uuid: 'group-obs-uuid',
+      concept: { uuid: 'group-concept' },
+      groupMembers: [strengthObs],
+    };
+
+    const flatObs = [groupObs, strengthObs];
+
+    // No formFieldPath on parent → backward compat → allow fallback
+    const matched = findObsByFormField(flatObs, [], childField);
+    expect(matched.length).toBe(1);
+    expect(matched[0]).toBe(strengthObs);
+  });
 });
 
 describe('ObsAdapter - handling nested obsGroups', () => {

--- a/src/adapters/obs-adapter.ts
+++ b/src/adapters/obs-adapter.ts
@@ -268,6 +268,11 @@ function handleAttachments(field: FormField, attachments: Attachment[] = []) {
  * Notes:
  * If the query by field-path returns an empty list, the function falls back to querying
  * by concept and uses `claimedObsIds` to exclude already assigned observations.
+ *
+ * When the field belongs to an obsGroup (i.e. `field.meta.groupId` is set), the concept
+ * fallback is scoped to observations that are members of the matching parent obsGroup.
+ * This prevents child obs from one obsGroup from being incorrectly assigned to fields
+ * in a different obsGroup that happens to share the same concept.
  */
 export function findObsByFormField(
   obsList: Array<OpenmrsObs>,
@@ -287,7 +292,31 @@ export function findObsByFormField(
   // We shall fall back to mapping by the associated concept
   // That being said, we shall find all matching obs and pick the one that wasn't previously claimed.
   if (!obs?.length) {
-    const obsByConcept = obsList.filter((obs) => obs.concept.uuid == field.questionOptions.concept);
+    let obsByConcept = obsList.filter((obs) => obs.concept.uuid == field.questionOptions.concept);
+
+    // If this field belongs to an obsGroup, restrict the concept fallback to
+    // respect obsGroup boundaries.  For each candidate obs we check whether it
+    // is a member of any obsGroup in the encounter.  Three cases:
+    //   1. The obs is standalone (not in any group) → allow (normal fallback).
+    //   2. The obs is in a group whose formFieldPath matches the expected
+    //      parent → allow (correct group).
+    //   3. The obs is in a group with a *different* formFieldPath → exclude
+    //      (prevents cross-group concept bleeding, e.g. PrEP → ARV).
+    //   4. The obs is in a group that has no formFieldPath (old encounter) →
+    //      allow (backward compatibility).
+    if (field.meta?.groupId) {
+      const parentPath = `rfe-forms-${field.meta.groupId}`;
+      obsByConcept = obsByConcept.filter((candidate) => {
+        // Find the obsGroup that owns this candidate (if any)
+        const ownerGroup = obsList.find(
+          (o) => o.groupMembers?.some((m) => m.uuid === candidate.uuid),
+        );
+        if (!ownerGroup) return true;                       // case 1: standalone
+        if (!ownerGroup.formFieldPath) return true;         // case 4: old encounter
+        return ownerGroup.formFieldPath == parentPath;      // case 2 or 3
+      });
+    }
+
     return claimedObsIds?.length ? obsByConcept.filter((obs) => !claimedObsIds.includes(obs.uuid)) : obsByConcept;
   }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Fixes a bug where `findObsByFormField` concept-only fallback ignores obsGroup boundaries, causing child observations from one obsGroup to bleed into fields of a different obsGroup that shares the same concept.

### Problem

When a form has multiple repeating obsGroups (e.g., ARV Medication and PrEP Drugs) whose child fields share common concepts (strength, unit, frequency, duration, qty prescribed, duration dispensed, qty dispensed), editing an encounter causes cross-group contamination:

1. `findObsByFormField` first tries to match obs by `formFieldPath + concept`
2. When that fails (ARV fields don't have PrEP paths), it falls back to **concept-only** matching
3. The fallback searches the entire flattened obs list without respecting obsGroup boundaries
4. ARV fields (processed first) steal PrEP obs via this fallback

### Solution

When a field belongs to an obsGroup (`field.meta.groupId` is set), the concept-only fallback now checks whether each candidate obs belongs to a different obsGroup:

- **Standalone obs** (not in any group) → allowed (normal fallback)
- **Obs in the correct parent group** (formFieldPath matches) → allowed
- **Obs in a different group** (formFieldPath doesn't match) → **excluded**
- **Obs in a group with no formFieldPath** (old encounter data) → allowed (backward compatibility)

### Tests

Added 3 new test cases to `obs-adapter.test.ts`:
- `Should scope concept fallback to the parent obsGroup when field has a groupId`
- `Should allow concept fallback within the correct parent obsGroup`
- `Should preserve backward compatibility when parent obsGroup has no formFieldPath`

All 38 tests pass (35 existing + 3 new).

## Screenshots

No UI changes — this is a logic fix in the obs adapter.

## Related Issue

<!-- https://issues.openmrs.org/browse/O3- -->
No existing Jira ticket. This was discovered while building pharmacy forms with multiple repeating obsGroups sharing child concepts.

## Other

This fix is backward compatible. Encounters saved without `formFieldPath` on parent obsGroups continue to work via the existing concept-only fallback.