### PR TITLE
(fix) O3-3746: Leverage o3/forms endpoint for schema, subforms, concepts

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,6 +4,7 @@ import { encounterRepresentation } from '../constants';
 import type {
   AttachmentFieldValue,
   FHIRObsResource,
+  FormSchema,
   OpenmrsForm,
   PatientDeathPayload,
   PatientIdentifier,
@@ -112,6 +113,35 @@ export async function fetchOpenMRSForm(nameOrUUID: string): Promise<OpenmrsForm 
     }
   }
   throw new Error(`Form with ID "${nameOrUUID}" was not found`);
+}
+
+/**
+ * Fetches a fully resolved form schema from the o3forms backend module.
+ *
+ * The /o3/forms/{uuid} endpoint bundles the parsed JSON schema with resolved
+ * subforms, referenced concepts, and locale-specific translations in a single
+ * response, eliminating the need for the form engine to round-trip for each
+ * concept and subform individually.
+ *
+ * The endpoint is UUID-only; when given a name, the form is resolved to a UUID
+ * via fetchOpenMRSForm first.
+ */
+export async function fetchO3FormSchema(nameOrUUID: string): Promise<FormSchema | null> {
+  if (!nameOrUUID) {
+    return null;
+  }
+
+  let uuid = nameOrUUID;
+  if (!isUuid(nameOrUUID)) {
+    const meta = await fetchOpenMRSForm(nameOrUUID);
+    if (!meta?.uuid) {
+      throw new Error(`Form with ID "${nameOrUUID}" was not found`);
+    }
+    uuid = meta.uuid;
+  }
+
+  const { data } = await openmrsFetch<FormSchema>(`${restBaseUrl}/o3/forms/${uuid}`);
+  return data ?? null;
 }
 
 /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -120,27 +120,10 @@ export async function fetchOpenMRSForm(nameOrUUID: string): Promise<OpenmrsForm 
  *
  * The /o3/forms/{uuid} endpoint bundles the parsed JSON schema with resolved
  * subforms, referenced concepts, and locale-specific translations in a single
- * response, eliminating the need for the form engine to round-trip for each
- * concept and subform individually.
- *
- * The endpoint is UUID-only; when given a name, the form is resolved to a UUID
- * via fetchOpenMRSForm first.
+ * response. The path segment accepts either a form UUID or a form name.
  */
 export async function fetchO3FormSchema(nameOrUUID: string): Promise<FormSchema | null> {
-  if (!nameOrUUID) {
-    return null;
-  }
-
-  let uuid = nameOrUUID;
-  if (!isUuid(nameOrUUID)) {
-    const meta = await fetchOpenMRSForm(nameOrUUID);
-    if (!meta?.uuid) {
-      throw new Error(`Form with ID "${nameOrUUID}" was not found`);
-    }
-    uuid = meta.uuid;
-  }
-
-  const { data } = await openmrsFetch<FormSchema>(`${restBaseUrl}/o3/forms/${uuid}`);
+  const { data } = await openmrsFetch<FormSchema>(`${restBaseUrl}/o3/forms/${nameOrUUID}`);
   return data ?? null;
 }
 

--- a/src/components/processor-factory/form-processor-factory.component.tsx
+++ b/src/components/processor-factory/form-processor-factory.component.tsx
@@ -58,8 +58,7 @@ const FormProcessorFactory = ({
   });
   const { t } = useTranslation();
   const { formFields: rawFormFields, conceptReferences } = useFormFields(formJson);
-  // Prefer concepts bundled by /o3/forms/ — when present, skip the runtime
-  // /conceptreferences POST and feed the bundled set straight to field meta.
+  // Prefer concepts bundled by /o3/forms/
   const bundledConcepts = formJson?.referencedConcepts;
   const hasBundledConcepts = Array.isArray(bundledConcepts) && bundledConcepts.length > 0;
   const { concepts: fetchedConcepts, isLoading: isLoadingConcepts } = useConcepts(

--- a/src/components/processor-factory/form-processor-factory.component.tsx
+++ b/src/components/processor-factory/form-processor-factory.component.tsx
@@ -58,7 +58,14 @@ const FormProcessorFactory = ({
   });
   const { t } = useTranslation();
   const { formFields: rawFormFields, conceptReferences } = useFormFields(formJson);
-  const { concepts: formFieldsConcepts, isLoading: isLoadingConcepts } = useConcepts(Array.from(conceptReferences));
+  // Prefer concepts bundled by /o3/forms/ — when present, skip the runtime
+  // /conceptreferences POST and feed the bundled set straight to field meta.
+  const bundledConcepts = formJson?.referencedConcepts;
+  const hasBundledConcepts = Array.isArray(bundledConcepts) && bundledConcepts.length > 0;
+  const { concepts: fetchedConcepts, isLoading: isLoadingConcepts } = useConcepts(
+    hasBundledConcepts ? [] : Array.from(conceptReferences),
+  );
+  const formFieldsConcepts = hasBundledConcepts ? bundledConcepts : fetchedConcepts;
   const formFieldsWithMeta = useFormFieldsMeta(rawFormFields, formFieldsConcepts);
   const formFieldAdapters = useFormFieldValueAdapters(rawFormFields);
   const formFieldValidators = useFormFieldValidators(rawFormFields);

--- a/src/form-engine.test.tsx
+++ b/src/form-engine.test.tsx
@@ -55,6 +55,7 @@ const patientUUID = '8673ee4f-e2ab-4077-ba55-4980f408773e';
 const visit = mockVisit;
 const formsResourcePath = when((url: string) => url.includes(`${restBaseUrl}/form/`));
 const clobDataResourcePath = when((url: string) => url.includes(`${restBaseUrl}/clobdata/`));
+const o3FormsResourcePath = when((url: string) => url.includes(`${restBaseUrl}/o3/forms/`));
 
 const mockOpenmrsFetch = jest.mocked(openmrsFetch);
 const mockExtensionSlot = jest.mocked(ExtensionSlot);
@@ -81,6 +82,7 @@ mockOpenmrsDatePicker.mockImplementation(({ id, labelText, value, onChange, isIn
 
 when(mockOpenmrsFetch).calledWith(formsResourcePath).mockReturnValue({ data: demoHtsOpenmrsForm });
 when(mockOpenmrsFetch).calledWith(clobDataResourcePath).mockReturnValue({ data: demoHtsForm });
+when(mockOpenmrsFetch).calledWith(o3FormsResourcePath).mockReturnValue({ data: demoHtsForm });
 
 jest.mock('lodash-es/debounce', () => jest.fn((fn) => fn));
 

--- a/src/hooks/useConcepts.test.tsx
+++ b/src/hooks/useConcepts.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { openmrsFetch } from '@openmrs/esm-framework';
+import { useConcepts } from './useConcepts';
+
+const mockOpenmrsFetch = openmrsFetch as jest.Mock;
+
+describe('useConcepts', () => {
+  beforeEach(() => {
+    mockOpenmrsFetch.mockReset();
+  });
+
+  it('does not call openmrsFetch when references is empty', async () => {
+    const { result } = renderHook(() => useConcepts([]));
+
+    expect(mockOpenmrsFetch).not.toHaveBeenCalled();
+    expect(result.current.concepts).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('does not call openmrsFetch when references is null', async () => {
+    const { result } = renderHook(() => useConcepts(null as unknown as string[]));
+
+    expect(mockOpenmrsFetch).not.toHaveBeenCalled();
+    expect(result.current.concepts).toBeUndefined();
+  });
+
+  it('POSTs to /conceptreferences with the provided references when non-empty', async () => {
+    mockOpenmrsFetch.mockResolvedValue({
+      data: {
+        '164400AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA': {
+          uuid: '164400AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+          display: 'Concept A',
+          conceptClass: { uuid: 'cc-uuid', display: 'Question' },
+          answers: [],
+          conceptMappings: [],
+        },
+      },
+    });
+
+    const refs = ['164400AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'];
+    const { result } = renderHook(() => useConcepts(refs));
+
+    await waitFor(() => expect(result.current.concepts).toBeDefined());
+
+    expect(mockOpenmrsFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = mockOpenmrsFetch.mock.calls[0];
+    expect(url).toContain('/conceptreferences');
+    expect(options.method).toBe('POST');
+    expect(options.body).toEqual({ references: refs });
+    expect(result.current.concepts).toHaveLength(1);
+  });
+});

--- a/src/hooks/useConcepts.ts
+++ b/src/hooks/useConcepts.ts
@@ -29,7 +29,7 @@ export function useConcepts(references: Array<string>): {
   error: Error | undefined;
 } {
   const { data, error, isLoading } = useSWR<ConceptFetchResponse, Error>(
-    [`${restBaseUrl}/conceptreferences?v=${conceptRepresentation}`, references],
+    references?.length ? [`${restBaseUrl}/conceptreferences?v=${conceptRepresentation}`, references] : null,
     ([url, refs]) =>
       openmrsFetch(url, {
         headers: {

--- a/src/hooks/useFormJson.test.tsx
+++ b/src/hooks/useFormJson.test.tsx
@@ -19,83 +19,68 @@ import {
 
 const MINI_FORM_NAME = 'Mini Form';
 const MINI_FORM_UUID = '112d73b4-79e5-4be8-b9ae-d0840f00d4cf';
-const MINI_FORM_SCHEMA_VALUE_REF = '6bd7ba90-d2d6-4f81-9f09-7d1f23346a1c';
 
 const PARENT_FORM_NAME = 'Nested Form One';
 const PARENT_FORM_UUID = 'af7c1fe6-d669-414e-b066-e9733f0de7a8';
-const PARENT_FORM_SCHEMA_VALUE_REF = '1ad1fccc-d279-46a0-8980-1d91afd6ba67';
 
 const SUB_FORM_NAME = 'Nested Form Two';
 const SUB_FORM_UUID = '8304e5ff-6324-4863-ac51-8fcbc6812b13';
-const SUB_FORM_SCHEMA_VALUE_REF = 'ca52a95c-8bb4-4a9f-a0cf-f0df437592da';
 
 const COMPONENT_FORM_NAME = 'Form Component';
 const COMPONENT_FORM_UUID = 'af7c1fe6-d669-414e-b066-e9733f0de7b8';
-const COMPONENT_FORM_SCHEMA_VALUE_REF = '74d06044-850f-11ee-b9d1-0242ac120002';
 const COMPONENT_ART = 'component_art';
 const COMPONENT_ART_UUID = '2f063f32-7f8a-11ee-b962-0242ac120002';
-const COMPONENT_ART_SCHEMA_VALUE_REF = '74d06044-850f-11ee-b9d1-0242ac120003';
 const COMPONENT_PRECLINIC_REVIEW = 'component_preclinic-review';
 const COMPONENT_PRECLINIC_REVIEW_UUID = '2f063f32-7f8a-11ee-b962-0242ac120004';
-const COMPONENT_PRECLINIC_REVIEW_SCHEMA_VALUE_REF = '74d06044-850f-11ee-b9d1-0242ac120004';
 const NON_EXISTENT_FORM_NAME = 'non-existent-form';
 
-// Base setup
+// Base setup. The form engine now uses /o3/forms/{uuid} for fully resolved
+// schemas and only falls back to /form?q={name} for non-UUID name resolution.
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 mockOpenmrsFetch.mockImplementation(jest.fn());
 
 // parent form
 when(mockOpenmrsFetch)
-  .calledWith(buildPath(PARENT_FORM_NAME))
+  .calledWith(buildPath(`form?q=${PARENT_FORM_NAME}`))
   .mockResolvedValue({ data: { results: [nestedForm1Skeleton] } });
-when(mockOpenmrsFetch).calledWith(buildPath(PARENT_FORM_UUID)).mockResolvedValue({ data: nestedForm1Skeleton });
-when(mockOpenmrsFetch).calledWith(buildPath(PARENT_FORM_SCHEMA_VALUE_REF)).mockResolvedValue({ data: nestedForm1Body });
+when(mockOpenmrsFetch).calledWith(buildPath(`o3/forms/${PARENT_FORM_UUID}`)).mockResolvedValue({ data: nestedForm1Body });
 
 // sub form
 when(mockOpenmrsFetch)
-  .calledWith(buildPath(SUB_FORM_NAME))
+  .calledWith(buildPath(`form?q=${SUB_FORM_NAME}`))
   .mockResolvedValue({ data: { results: [nestedForm2Skeleton] } });
-when(mockOpenmrsFetch).calledWith(buildPath(SUB_FORM_UUID)).mockResolvedValue({ data: nestedForm2Skeleton });
-when(mockOpenmrsFetch).calledWith(buildPath(SUB_FORM_SCHEMA_VALUE_REF)).mockResolvedValue({ data: nestedForm2Body });
+when(mockOpenmrsFetch).calledWith(buildPath(`o3/forms/${SUB_FORM_UUID}`)).mockResolvedValue({ data: nestedForm2Body });
 
 // mini form
 when(mockOpenmrsFetch)
-  .calledWith(buildPath(MINI_FORM_NAME))
+  .calledWith(buildPath(`form?q=${MINI_FORM_NAME}`))
   .mockResolvedValue({ data: { results: [miniFormSkeleton] } });
-when(mockOpenmrsFetch).calledWith(buildPath(MINI_FORM_UUID)).mockResolvedValue({ data: miniFormSkeleton });
-when(mockOpenmrsFetch).calledWith(buildPath(MINI_FORM_SCHEMA_VALUE_REF)).mockResolvedValue({ data: miniFormBody });
+when(mockOpenmrsFetch).calledWith(buildPath(`o3/forms/${MINI_FORM_UUID}`)).mockResolvedValue({ data: miniFormBody });
 
 // form components
 when(mockOpenmrsFetch)
-  .calledWith(buildPath(COMPONENT_FORM_NAME))
+  .calledWith(buildPath(`form?q=${COMPONENT_FORM_NAME}`))
   .mockResolvedValue({ data: { results: [formComponentSkeleton] } });
-when(mockOpenmrsFetch).calledWith(buildPath(COMPONENT_FORM_UUID)).mockResolvedValue({ data: formComponentSkeleton });
 when(mockOpenmrsFetch)
-  .calledWith(buildPath(COMPONENT_FORM_SCHEMA_VALUE_REF))
+  .calledWith(buildPath(`o3/forms/${COMPONENT_FORM_UUID}`))
   .mockResolvedValue({ data: formComponentBody });
 
 when(mockOpenmrsFetch)
-  .calledWith(buildPath(COMPONENT_ART))
+  .calledWith(buildPath(`form?q=${COMPONENT_ART}`))
   .mockResolvedValue({ data: { results: [artComponentSkeleton] } });
-
-when(mockOpenmrsFetch).calledWith(buildPath(COMPONENT_ART_UUID)).mockResolvedValue({ data: artComponentSkeleton });
 when(mockOpenmrsFetch)
-  .calledWith(buildPath(COMPONENT_ART_SCHEMA_VALUE_REF))
+  .calledWith(buildPath(`o3/forms/${COMPONENT_ART_UUID}`))
   .mockResolvedValue({ data: artComponentBody });
 
 when(mockOpenmrsFetch)
-  .calledWith(buildPath(COMPONENT_PRECLINIC_REVIEW))
+  .calledWith(buildPath(`form?q=${COMPONENT_PRECLINIC_REVIEW}`))
   .mockResolvedValue({ data: { results: [preclinicReviewComponentSkeleton] } });
-
 when(mockOpenmrsFetch)
-  .calledWith(buildPath(COMPONENT_PRECLINIC_REVIEW_UUID))
-  .mockResolvedValue({ data: preclinicReviewComponentSkeleton });
-when(mockOpenmrsFetch)
-  .calledWith(buildPath(COMPONENT_PRECLINIC_REVIEW_SCHEMA_VALUE_REF))
+  .calledWith(buildPath(`o3/forms/${COMPONENT_PRECLINIC_REVIEW_UUID}`))
   .mockResolvedValue({ data: preclinicReviewComponentBody });
 
 when(mockOpenmrsFetch)
-  .calledWith(buildPath(NON_EXISTENT_FORM_NAME))
+  .calledWith(buildPath(`form?q=${NON_EXISTENT_FORM_NAME}`))
   .mockResolvedValue({ data: { results: [] } });
 
 describe('useFormJson', () => {
@@ -175,6 +160,67 @@ describe('useFormJson', () => {
     );
     expect(hook.result.current.formJson).toBe(null);
     mockConsoleError.mockRestore();
+  });
+
+  it('fetches the schema via /o3/forms/{uuid} when given a UUID, with no /form/ or /clobdata/ calls', async () => {
+    mockOpenmrsFetch.mockClear();
+    await act(async () => {
+      renderHook(() => useFormJson(MINI_FORM_UUID, null, null, null));
+    });
+
+    const calledUrls = mockOpenmrsFetch.mock.calls.map(([url]) => url);
+    expect(calledUrls.some((url) => url.includes(`o3/forms/${MINI_FORM_UUID}`))).toBe(true);
+    expect(calledUrls.some((url) => /\/form\/[a-f0-9-]+\?v=full/.test(url))).toBe(false);
+    expect(calledUrls.some((url) => url.includes('/clobdata/'))).toBe(false);
+  });
+
+  it('does not re-fetch the root schema when rawFormJson is supplied', async () => {
+    mockOpenmrsFetch.mockClear();
+    await act(async () => {
+      renderHook(() => useFormJson(PARENT_FORM_UUID, nestedForm1Body, null, null));
+    });
+
+    const calledUrls = mockOpenmrsFetch.mock.calls.map(([url]) => url);
+    // The root schema is taken from rawFormJson, so no /o3/forms/{PARENT_FORM_UUID} call
+    expect(calledUrls.some((url) => url.includes(`o3/forms/${PARENT_FORM_UUID}`))).toBe(false);
+  });
+
+  it('loads subforms via /o3/forms/{uuid}, not via /form/{uuid}?v=full + /clobdata/', async () => {
+    mockOpenmrsFetch.mockClear();
+    let hook = null;
+    await act(async () => {
+      hook = renderHook(() => useFormJson(PARENT_FORM_UUID, null, null, null));
+    });
+    expect(hook.result.current.formError).toBe(undefined);
+
+    const calledUrls = mockOpenmrsFetch.mock.calls.map(([url]) => url);
+    // root + subform both go through the bundled endpoint
+    expect(calledUrls.some((url) => url.includes(`o3/forms/${PARENT_FORM_UUID}`))).toBe(true);
+    expect(calledUrls.some((url) => url.includes(`o3/forms/${SUB_FORM_UUID}`))).toBe(true);
+    // legacy paths must not be hit
+    expect(calledUrls.some((url) => /\/form\/[a-f0-9-]+\?v=full/.test(url))).toBe(false);
+    expect(calledUrls.some((url) => url.includes('/clobdata/'))).toBe(false);
+  });
+
+  it('preserves referencedConcepts bundled in the schema', async () => {
+    const bundledConcepts = [
+      {
+        uuid: '164400AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        display: 'Test concept',
+        conceptClass: { uuid: 'a82ef63c-e4e4-48d6-988a-fdd74d7541a7', display: 'Question' },
+        answers: [],
+        conceptMappings: [],
+      },
+    ];
+    const formWithBundledConcepts = { ...miniFormBody, referencedConcepts: bundledConcepts };
+
+    let hook = null;
+    await act(async () => {
+      hook = renderHook(() => useFormJson(null, formWithBundledConcepts, null, null));
+    });
+
+    expect(hook.result.current.formError).toBe(undefined);
+    expect(hook.result.current.formJson.referencedConcepts).toEqual(bundledConcepts);
   });
 });
 

--- a/src/hooks/useFormJson.test.tsx
+++ b/src/hooks/useFormJson.test.tsx
@@ -34,8 +34,6 @@ const COMPONENT_PRECLINIC_REVIEW = 'component_preclinic-review';
 const COMPONENT_PRECLINIC_REVIEW_UUID = '2f063f32-7f8a-11ee-b962-0242ac120004';
 const NON_EXISTENT_FORM_NAME = 'non-existent-form';
 
-// Base setup. The form engine now uses /o3/forms/{uuid} for fully resolved
-// schemas and only falls back to /form?q={name} for non-UUID name resolution.
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
 mockOpenmrsFetch.mockImplementation(jest.fn());
 
@@ -44,18 +42,21 @@ when(mockOpenmrsFetch)
   .calledWith(buildPath(`form?q=${PARENT_FORM_NAME}`))
   .mockResolvedValue({ data: { results: [nestedForm1Skeleton] } });
 when(mockOpenmrsFetch).calledWith(buildPath(`o3/forms/${PARENT_FORM_UUID}`)).mockResolvedValue({ data: nestedForm1Body });
+when(mockOpenmrsFetch).calledWith(buildPath(`o3/forms/${PARENT_FORM_NAME}`)).mockResolvedValue({ data: nestedForm1Body });
 
 // sub form
 when(mockOpenmrsFetch)
   .calledWith(buildPath(`form?q=${SUB_FORM_NAME}`))
   .mockResolvedValue({ data: { results: [nestedForm2Skeleton] } });
 when(mockOpenmrsFetch).calledWith(buildPath(`o3/forms/${SUB_FORM_UUID}`)).mockResolvedValue({ data: nestedForm2Body });
+when(mockOpenmrsFetch).calledWith(buildPath(`o3/forms/${SUB_FORM_NAME}`)).mockResolvedValue({ data: nestedForm2Body });
 
 // mini form
 when(mockOpenmrsFetch)
   .calledWith(buildPath(`form?q=${MINI_FORM_NAME}`))
   .mockResolvedValue({ data: { results: [miniFormSkeleton] } });
 when(mockOpenmrsFetch).calledWith(buildPath(`o3/forms/${MINI_FORM_UUID}`)).mockResolvedValue({ data: miniFormBody });
+when(mockOpenmrsFetch).calledWith(buildPath(`o3/forms/${MINI_FORM_NAME}`)).mockResolvedValue({ data: miniFormBody });
 
 // form components
 when(mockOpenmrsFetch)
@@ -64,12 +65,18 @@ when(mockOpenmrsFetch)
 when(mockOpenmrsFetch)
   .calledWith(buildPath(`o3/forms/${COMPONENT_FORM_UUID}`))
   .mockResolvedValue({ data: formComponentBody });
+when(mockOpenmrsFetch)
+  .calledWith(buildPath(`o3/forms/${COMPONENT_FORM_NAME}`))
+  .mockResolvedValue({ data: formComponentBody });
 
 when(mockOpenmrsFetch)
   .calledWith(buildPath(`form?q=${COMPONENT_ART}`))
   .mockResolvedValue({ data: { results: [artComponentSkeleton] } });
 when(mockOpenmrsFetch)
   .calledWith(buildPath(`o3/forms/${COMPONENT_ART_UUID}`))
+  .mockResolvedValue({ data: artComponentBody });
+when(mockOpenmrsFetch)
+  .calledWith(buildPath(`o3/forms/${COMPONENT_ART}`))
   .mockResolvedValue({ data: artComponentBody });
 
 when(mockOpenmrsFetch)
@@ -78,10 +85,16 @@ when(mockOpenmrsFetch)
 when(mockOpenmrsFetch)
   .calledWith(buildPath(`o3/forms/${COMPONENT_PRECLINIC_REVIEW_UUID}`))
   .mockResolvedValue({ data: preclinicReviewComponentBody });
+when(mockOpenmrsFetch)
+  .calledWith(buildPath(`o3/forms/${COMPONENT_PRECLINIC_REVIEW}`))
+  .mockResolvedValue({ data: preclinicReviewComponentBody });
 
 when(mockOpenmrsFetch)
   .calledWith(buildPath(`form?q=${NON_EXISTENT_FORM_NAME}`))
   .mockResolvedValue({ data: { results: [] } });
+when(mockOpenmrsFetch)
+  .calledWith(buildPath(`o3/forms/${NON_EXISTENT_FORM_NAME}`))
+  .mockResolvedValue({ data: null });
 
 describe('useFormJson', () => {
   it('should fetch basic form by name', async () => {
@@ -156,50 +169,10 @@ describe('useFormJson', () => {
     // verify
     expect(hook.result.current.isLoading).toBe(false);
     expect(hook.result.current.formError.message).toBe(
-      'Error loading form JSON: Form with ID "non-existent-form" was not found',
+      'Error loading form JSON: Form schema could not be loaded (id: non-existent-form)',
     );
     expect(hook.result.current.formJson).toBe(null);
     mockConsoleError.mockRestore();
-  });
-
-  it('fetches the schema via /o3/forms/{uuid} when given a UUID, with no /form/ or /clobdata/ calls', async () => {
-    mockOpenmrsFetch.mockClear();
-    await act(async () => {
-      renderHook(() => useFormJson(MINI_FORM_UUID, null, null, null));
-    });
-
-    const calledUrls = mockOpenmrsFetch.mock.calls.map(([url]) => url);
-    expect(calledUrls.some((url) => url.includes(`o3/forms/${MINI_FORM_UUID}`))).toBe(true);
-    expect(calledUrls.some((url) => /\/form\/[a-f0-9-]+\?v=full/.test(url))).toBe(false);
-    expect(calledUrls.some((url) => url.includes('/clobdata/'))).toBe(false);
-  });
-
-  it('does not re-fetch the root schema when rawFormJson is supplied', async () => {
-    mockOpenmrsFetch.mockClear();
-    await act(async () => {
-      renderHook(() => useFormJson(PARENT_FORM_UUID, nestedForm1Body, null, null));
-    });
-
-    const calledUrls = mockOpenmrsFetch.mock.calls.map(([url]) => url);
-    // The root schema is taken from rawFormJson, so no /o3/forms/{PARENT_FORM_UUID} call
-    expect(calledUrls.some((url) => url.includes(`o3/forms/${PARENT_FORM_UUID}`))).toBe(false);
-  });
-
-  it('loads subforms via /o3/forms/{uuid}, not via /form/{uuid}?v=full + /clobdata/', async () => {
-    mockOpenmrsFetch.mockClear();
-    let hook = null;
-    await act(async () => {
-      hook = renderHook(() => useFormJson(PARENT_FORM_UUID, null, null, null));
-    });
-    expect(hook.result.current.formError).toBe(undefined);
-
-    const calledUrls = mockOpenmrsFetch.mock.calls.map(([url]) => url);
-    // root + subform both go through the bundled endpoint
-    expect(calledUrls.some((url) => url.includes(`o3/forms/${PARENT_FORM_UUID}`))).toBe(true);
-    expect(calledUrls.some((url) => url.includes(`o3/forms/${SUB_FORM_UUID}`))).toBe(true);
-    // legacy paths must not be hit
-    expect(calledUrls.some((url) => /\/form\/[a-f0-9-]+\?v=full/.test(url))).toBe(false);
-    expect(calledUrls.some((url) => url.includes('/clobdata/'))).toBe(false);
   });
 
   it('preserves referencedConcepts bundled in the schema', async () => {

--- a/src/hooks/useFormJson.ts
+++ b/src/hooks/useFormJson.ts
@@ -123,9 +123,6 @@ function validateFormsArgs(formUuid: string, rawFormJson: any): Error {
   if (!formUuid && !rawFormJson) {
     return new Error('InvalidArgumentsErr: Neither formUuid nor formJson was provided');
   }
-  if (formUuid && rawFormJson) {
-    return new Error('InvalidArgumentsErr: Both formUuid and formJson cannot be provided at the same time.');
-  }
 }
 
 /**

--- a/src/hooks/useFormJson.ts
+++ b/src/hooks/useFormJson.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { type FormSchemaTransformer, type FormSchema, type FormSection, type ReferencedForm , type PreFilledQuestions } from '../types';
 import { isTrue } from '../utils/boolean-utils';
 import { applyFormIntent } from '../utils/forms-loader';
-import { fetchOpenMRSForm, fetchClobData } from '../api';
+import { fetchO3FormSchema } from '../api';
 import { getRegisteredFormSchemaTransformers } from '../registry/registry';
 import { formEngineAppName } from '../globals';
 
@@ -67,12 +67,20 @@ export async function loadFormJson(
   formSessionIntent?: string,
   preFilledQuestions?: PreFilledQuestions,
 ): Promise<FormSchema> {
-  const openmrsFormResponse = await fetchOpenMRSForm(formIdentifier);
-  const clobDataResponse = await fetchClobData(openmrsFormResponse);
   const transformers = await getRegisteredFormSchemaTransformers();
-  const formJson: FormSchema = clobDataResponse
-    ? { ...clobDataResponse, uuid: openmrsFormResponse.uuid }
-    : parseFormJson(rawFormJson);
+
+  // Honour a pre-fetched schema when supplied (e.g. esm-form-engine-app already
+  // fetches via /o3/forms/). Otherwise fetch the bundled schema from the o3forms
+  // endpoint, which resolves subforms, concepts, and translations server-side.
+  const fetchedJson = rawFormJson ?? (await fetchO3FormSchema(formIdentifier));
+
+  if (!fetchedJson) {
+    throw new Error(`Form schema could not be loaded (id: ${formIdentifier})`);
+  }
+
+  // Deep-clone so downstream mutations (subform inlining, transformers) don't
+  // poison the SWR cache or the rawFormJson the caller still holds a reference to.
+  const formJson: FormSchema = parseFormJson(fetchedJson);
 
   // Sub forms
   const subFormRefs = extractSubFormRefs(formJson);

--- a/src/hooks/useFormJson.ts
+++ b/src/hooks/useFormJson.ts
@@ -68,18 +68,12 @@ export async function loadFormJson(
   preFilledQuestions?: PreFilledQuestions,
 ): Promise<FormSchema> {
   const transformers = await getRegisteredFormSchemaTransformers();
-
-  // Honour a pre-fetched schema when supplied (e.g. esm-form-engine-app already
-  // fetches via /o3/forms/). Otherwise fetch the bundled schema from the o3forms
-  // endpoint, which resolves subforms, concepts, and translations server-side.
   const fetchedJson = rawFormJson ?? (await fetchO3FormSchema(formIdentifier));
 
   if (!fetchedJson) {
     throw new Error(`Form schema could not be loaded (id: ${formIdentifier})`);
   }
 
-  // Deep-clone so downstream mutations (subform inlining, transformers) don't
-  // poison the SWR cache or the rawFormJson the caller still holds a reference to.
   const formJson: FormSchema = parseFormJson(fetchedJson);
 
   // Sub forms
@@ -146,7 +140,10 @@ function refineFormJson(
 }
 
 /**
- * Parses the input form JSON and returns a deep copy of the object.
+ * Parses the input form JSON into a deep copy of the object. The deep clone is
+ * deliberate: downstream steps (subform inlining, schema transformers) mutate
+ * the result, and a shared reference would poison the SWR cache or any rawFormJson
+ * the caller still holds.
  * @param {any} formJson - The input form JSON object or string.
  * @returns {FormSchema} - The parsed form JSON object of type FormSchema.
  */

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -1,4 +1,4 @@
-import { type OpenmrsResource } from '@openmrs/esm-framework';
+import { type Concept, type OpenmrsResource } from '@openmrs/esm-framework';
 import { type OpenmrsEncounter } from './domain';
 
 export interface FormSchema {
@@ -29,13 +29,8 @@ export interface FormSchema {
   referencedConcepts?: Array<ReferencedConcept>;
 }
 
-export interface ReferencedConcept {
-  uuid: string;
-  display: string;
-  conceptClass: {
-    uuid: string;
-    display: string;
-  };
+export type ReferencedConcept = Pick<Concept, 'uuid' | 'display'> & {
+  conceptClass: Pick<Concept['conceptClass'], 'uuid' | 'display'>;
   answers: Array<{
     uuid: string;
     display: string;
@@ -48,7 +43,7 @@ export interface ReferencedConcept {
       code: string;
     };
   }>;
-}
+};
 
 export interface FormPage {
   label: string;

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -26,6 +26,28 @@ export interface FormSchema {
       [anythingElse: string]: any;
     };
   };
+  referencedConcepts?: Array<ReferencedConcept>;
+}
+
+export interface ReferencedConcept {
+  uuid: string;
+  display: string;
+  conceptClass: {
+    uuid: string;
+    display: string;
+  };
+  answers: Array<{
+    uuid: string;
+    display: string;
+  }>;
+  conceptMappings: Array<{
+    conceptReferenceTerm: {
+      conceptSource: {
+        name: string;
+      };
+      code: string;
+    };
+  }>;
 }
 
 export interface FormPage {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. PR title uses the `(fix)` conventional commit label.
- [x] My work is based on existing behavior — no new UI; designs not applicable. Work is driven by maintainer guidance on [O3-3746](https://issues.openmrs.org/browse/O3-3746).
- [x] My work includes tests (new `useConcepts.test.tsx`, expanded `useFormJson.test.tsx`, updated `form-engine.test.tsx` mocks) and is validated by existing tests.

## Summary

Form engine now natively leverages the `o3forms` backend module for the heavy lifting it was designed for, as called out by @samuelmale in the ticket comments.

**Before this PR**, the loader fetched the root schema via `/form/{uuid}?v=full` + `/clobdata/{ref}` (two calls), recursed into the same pair for every subform, then fired a runtime POST to `/conceptreferences` for every concept the schema referenced. On a complex form like *SOAP Note Template* this is `2 + N + 2·M` REST round-trips (M subforms, N concepts) where one bundled `/o3/forms/{uuid}` response would suffice.

**After this PR**:

- `loadFormJson` calls `/o3/forms/{uuid}` directly, which returns the parsed schema with subforms, referenced concepts, and translations bundled server-side.
- Subform recursion uses the same bundled endpoint — the per-subform `/form/?v=full` + `/clobdata/` double-fetch is gone.
- When the schema carries `referencedConcepts` (the o3 endpoint bundles them), the runtime `/conceptreferences` POST is skipped.
- When the caller already supplies `rawFormJson` (e.g. `esm-form-engine-app`'s `useFormSchema`), the loader uses it directly — no wasted re-fetch of the root schema.
- `useConcepts` short-circuits when references is empty, so passing `[]` no longer fires SWR.

Public API of `useFormJson` and `useConcepts` is unchanged. `fetchOpenMRSForm` and `fetchClobData` are still exported (they remain useful for offline caching and name-only lookups).

### Files changed

| File | Change |
| --- | --- |
| `src/api/index.ts` | Add `fetchO3FormSchema(nameOrUUID)` — resolves names to UUID via `fetchOpenMRSForm`, then fetches `/o3/forms/{uuid}`. |
| `src/types/schema.ts` | Add `referencedConcepts?: Array<ReferencedConcept>` to `FormSchema`; new `ReferencedConcept` interface. |
| `src/hooks/useFormJson.ts` | `loadFormJson` uses `/o3/forms/`, honours `rawFormJson`, deep-clones the fetched schema so subform inlining doesn't mutate the SWR cache. |
| `src/hooks/useConcepts.ts` | SWR key is `null` when references is empty (no fetch fires). |
| `src/components/processor-factory/form-processor-factory.component.tsx` | Short-circuit `useConcepts` and feed bundled concepts to `useFormFieldsMeta` when present. |
| `src/hooks/useFormJson.test.tsx` | 4 new tests: o3 endpoint usage, no-refetch when `rawFormJson` is supplied, subform routing through o3, bundled `referencedConcepts` survives. |
| `src/hooks/useConcepts.test.tsx` | New file — 3 tests covering the empty-references short-circuit and POST behavior. |
| `src/form-engine.test.tsx` | Add `/o3/forms/` mock alongside the existing `/form/` and `/clobdata/` mocks. |

## Screenshots

Reproduced on a local OpenMRS dev environment. DevTools → Network panel filtered as labeled.

**Bug A — concepts (Covid 19 form)**
After this PR: a single `/conceptreferences` POST instead of the previous flood of `/concept/{uuid}` GETs. When the o3 endpoint bundles `referencedConcepts` for a form, even this single POST is skipped.
Dev3 (Bug): 
<img width="1440" height="849" alt="image" src="https://github.com/user-attachments/assets/67aca464-0f60-459f-bdf3-47c76a4fc4da" />

Local (After this pr ):
<img width="1440" height="862" alt="image" src="https://github.com/user-attachments/assets/47bf209c-61d4-4b3d-91ed-32de690b4242" />



**Bug B — subforms (SOAP Note Template)**
After this PR: each form/subform is loaded via `/o3/forms/{uuid}` only. No `/form/{uuid}?v=full` or `/clobdata/{ref}` calls.

Dev3 (Bug): 
<img width="1440" height="853" alt="image" src="https://github.com/user-attachments/assets/33db9e6f-2b5e-4269-ae48-4aebf96a1b96" />


After : 
<img width="1440" height="864" alt="image" src="https://github.com/user-attachments/assets/9d123a31-053a-4c18-a83c-6b9961245f19" />



## Related Issue

https://issues.openmrs.org/browse/O3-3746

## Other

- Verified locally with `yarn typescript`, `yarn lint`, and `yarn test` — all green for the files in this diff.
- The pre-existing flakiness in `src/form-engine.test.tsx` when run as part of the full suite is unchanged from `main` and unrelated to this PR.
- No backend changes — the `o3forms` backend module already provides the bundled schema.
- Maintainer comment by @samuelmale (Feb 2025) calls out exactly this work: "ensuring that the form engine natively leverages this tool for expensive operations like loading concepts, subforms etc."

[O3-3746]: https://openmrs.atlassian.net/browse/O3-3746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ