### PR TITLE
(feat) O3-4795: Show character counter when maxLength is set on text fields

### DIFF
--- a/src/components/inputs/text/text.component.tsx
+++ b/src/components/inputs/text/text.component.tsx
@@ -41,6 +41,7 @@ const TextField: React.FC<FormFieldInputProps> = ({ field, value, errors, warnin
         <Layer>
           <TextInput
             disabled={field.isDisabled}
+            enableCounter={!!(field.questionOptions.max || field.questionOptions.maxLength)}
             id={field.id}
             invalid={errors.length > 0}
             invalidText={errors[0]?.message}

--- a/src/components/inputs/text/text.test.tsx
+++ b/src/components/inputs/text/text.test.tsx
@@ -191,4 +191,23 @@ describe('Text field input', () => {
 
     expect(inputField).toBeDisabled();
   });
+
+  it('should show character counter when maxLength is set', async () => {
+    await renderForm({
+      ...textValues,
+      field: {
+        ...textValues.field,
+        questionOptions: {
+          ...textValues.field.questionOptions,
+          maxLength: 100,
+        },
+      },
+    });
+    expect(screen.getByText('0/100')).toBeInTheDocument();
+  });
+
+  it('should not show character counter when maxLength is not set', async () => {
+    await renderForm(textValues);
+    expect(screen.queryByText(/\/\d+/)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

Carbon's `TextInput` already received the `maxCount` prop from `questionOptions.maxLength` (or `.max`), but `enableCounter` was never set — so no character counter was ever shown regardless of the schema value.

This PR wires `enableCounter` to `true` whenever `maxLength` or `max` is present, so a live character count (e.g. `0/100`) is displayed as the user types.

**Before:** `maxCount` passed, counter never displayed.
**After:** counter shows remaining characters when `maxLength` is set.

## Screenshots

N/A — character counter is rendered natively by the Carbon `TextInput` component when `enableCounter` is `true`.

## Related Issue

O3-4795

## Other

N/A