### PR TITLE
(fix) Clear RHF state when deleting a repeat-group row

### DIFF
--- a/src/components/repeat/repeat.component.tsx
+++ b/src/components/repeat/repeat.component.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import type { FormField, FormFieldInputProps, RenderType } from '../../types';
 import { evaluateAsyncExpression, evaluateExpression } from '../../utils/expression-runner';
 import { isEmpty } from '../../validators/form-validator';
@@ -19,8 +18,6 @@ const renderingByTypeMap: Record<string, RenderType> = {
 };
 
 const Repeat: React.FC<FormFieldInputProps> = ({ field }) => {
-  const { t } = useTranslation();
-  const isGrouped = useMemo(() => field.questions?.length > 1, [field]);
   const [counter, setCounter] = useState(0);
   const [rows, setRows] = useState([]);
   const context = useFormProviderContext();

--- a/src/components/repeat/repeat.component.tsx
+++ b/src/components/repeat/repeat.component.tsx
@@ -30,7 +30,7 @@ const Repeat: React.FC<FormFieldInputProps> = ({ field }) => {
     sessionMode,
     formFieldAdapters,
     formFields,
-    methods: { getValues, setValue },
+    methods: { getValues, setValue, unregister },
     addFormField,
     removeFormField,
     deletedFields,
@@ -117,6 +117,10 @@ const Repeat: React.FC<FormFieldInputProps> = ({ field }) => {
       }
     } else {
       clearSubmission(field);
+      // Unregister from react-hook-form so a re-added row with the same id
+      // starts empty instead of rehydrating the deleted row's value.
+      unregister(field.id);
+      field.questions?.forEach((child) => unregister(child.id));
     }
     setRows(rows.filter((q) => q.id !== field.id));
     setDeletedFields([...deletedFields, field]);

--- a/src/form-engine.test.tsx
+++ b/src/form-engine.test.tsx
@@ -1108,6 +1108,34 @@ describe('Form engine component', () => {
 
       expect(removeGroupButton).not.toBeInTheDocument();
     });
+
+    it('should not rehydrate values from a deleted row when a new row is added in its place', async () => {
+      await act(async () => {
+        renderForm(null, obsGroupTestForm);
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Add' }));
+
+      const maleRadios = screen.getAllByRole('radio', { name: /^male$/i });
+      expect(maleRadios).toHaveLength(2);
+      await user.click(maleRadios[1]);
+      expect(maleRadios[1]).toBeChecked();
+
+      await user.click(screen.getByRole('button', { name: /Remove/i }));
+      await waitFor(() => {
+        expect(screen.getAllByRole('radio', { name: /^male$/i })).toHaveLength(1);
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Add' }));
+
+      await waitFor(() => {
+        const maleRadiosAfterReadd = screen.getAllByRole('radio', { name: /^male$/i });
+        const femaleRadiosAfterReadd = screen.getAllByRole('radio', { name: /female/i });
+        expect(maleRadiosAfterReadd).toHaveLength(2);
+        expect(maleRadiosAfterReadd[1]).not.toBeChecked();
+        expect(femaleRadiosAfterReadd[1]).not.toBeChecked();
+      });
+    });
   });
 
   describe('Read only mode', () => {

--- a/src/form-engine.test.tsx
+++ b/src/form-engine.test.tsx
@@ -1116,11 +1116,12 @@ describe('Form engine component', () => {
 
       await user.click(screen.getByRole('button', { name: 'Add' }));
 
+      let maleRadios: HTMLElement[];
       await waitFor(() => {
-        expect(screen.getAllByRole('radio', { name: /^male$/i })).toHaveLength(2);
+        maleRadios = screen.getAllByRole('radio', { name: /^male$/i });
+        expect(maleRadios).toHaveLength(2);
       });
 
-      const maleRadios = screen.getAllByRole('radio', { name: /^male$/i });
       await user.click(maleRadios[1]);
       expect(maleRadios[1]).toBeChecked();
 

--- a/src/form-engine.test.tsx
+++ b/src/form-engine.test.tsx
@@ -1116,8 +1116,11 @@ describe('Form engine component', () => {
 
       await user.click(screen.getByRole('button', { name: 'Add' }));
 
+      await waitFor(() => {
+        expect(screen.getAllByRole('radio', { name: /^male$/i })).toHaveLength(2);
+      });
+
       const maleRadios = screen.getAllByRole('radio', { name: /^male$/i });
-      expect(maleRadios).toHaveLength(2);
       await user.click(maleRadios[1]);
       expect(maleRadios[1]).toBeChecked();
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The `Repeat` component derives its row-id counter from the live count of rendered rows. That means deleting a row and clicking `Add` again produces a new row with the same field id as the deleted one. React Hook Form keeps registered values by field name/id, so the re-added row silently inherited whatever the deleted row had contained. In practice, a user who "deleted" a contact and entered a new one could end up submitting the old contact's data.

This PR:

- Calls `unregister` on the removed field (and its children, for `obsGroup` rows) in `removeNthRow`, so fresh rows start empty. The voided-row branch (edit mode) still skips `unregister`, because those entries must survive to persist the void on submit.
- Adds a regression test under the `Obs group` describe block that selects a radio in a re-added row, deletes and re-adds the row, and asserts the new row's radios are unchecked.
- Drops the unused `useTranslation` hook and `isGrouped` memo from the component.

Verified manually in the form-builder preview (linked against the local engine-lib) with a minimal repeating `obsGroup` schema: filling a name, deleting the row, and clicking Add now yields an empty row.

## Screenshots

### Before

https://github.com/user-attachments/assets/98f0cef6-4194-4f2b-a96a-ebb704311e02

### After

https://github.com/user-attachments/assets/3b9b31a9-1e5c-4133-8569-09bddef619f8

## Related Issue

None.

## Other

This regression was reported on today's coffee break call by Temiye from the NMRS team