### PR TITLE
(fix) Suffix field ids correctly when they share a prefix in cloned expressions

### DIFF
--- a/src/components/repeat/helpers.ts
+++ b/src/components/repeat/helpers.ts
@@ -59,13 +59,18 @@ export function cloneRepeatField(srcField: FormField, value: OpenmrsResource, id
 }
 
 export function updateFieldIdInExpression(expression: string, index: number, questionIds: string[]) {
-  let uniqueQuestionIds = [...new Set(questionIds)];
-  uniqueQuestionIds.forEach((id) => {
-    if (expression.match(id)) {
-      expression = expression.replace(new RegExp(id, 'g'), `${id}_${index}`);
-    }
-  });
-  return expression;
+  const uniqueQuestionIds = [...new Set(questionIds)];
+  if (!uniqueQuestionIds.length) {
+    return expression;
+  }
+  // Sort by length desc so longer ids are tried before their shorter prefixes (e.g. `status_code` before `status`).
+  // Word boundaries keep the match from landing inside a longer identifier; regex metachars in ids are escaped.
+  const pattern = uniqueQuestionIds
+    .slice()
+    .sort((a, b) => b.length - a.length)
+    .map((id) => id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|');
+  return expression.replace(new RegExp(`\\b(?:${pattern})\\b`, 'g'), (match) => `${match}_${index}`);
 }
 
 export function disableRepeatAddButton(limit: string | number, counter: number) {

--- a/src/components/repeat/repeat.test.ts
+++ b/src/components/repeat/repeat.test.ts
@@ -26,4 +26,16 @@ describe('RepeatingFieldComponent - handleExpressionFieldIdUpdate', () => {
       "myValue > today() || myValue <= '1/1/1890' || myValue > useFieldValue('visit_date') || myValue < useFieldValue('visit_date')",
     );
   });
+
+  it('Should correctly suffix ids even when one id is a substring of another', () => {
+    // Probe: when two sibling ids share a prefix (e.g. `status` and `status_code`),
+    // naive /id/g replacement mangles the longer id.
+    const expression = "status === 'active' && status_code === '123'";
+    const fieldIds = ['status', 'status_code'];
+    const index = 1;
+
+    const updatedExpression = updateFieldIdInExpression(expression, index, fieldIds);
+
+    expect(updatedExpression).toEqual("status_1 === 'active' && status_code_1 === '123'");
+  });
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

`updateFieldIdInExpression` in `src/components/repeat/helpers.ts` rewrites field ids inside hide/calculate/`js_expression` expressions when a repeating row is cloned. It used `new RegExp(id, 'g')` per id with no escaping or boundaries, so when two sibling ids in the same repeating group shared a prefix, the replacement for the shorter id greedily consumed the shorter id inside the longer one.

Example: ids `status` and `status_code` in `"status === 'active' && status_code === '123'"` became `"status_1 === 'active' && status_1_code === '123'"` — `status_1_code` doesn't exist, and the expression runner silently returns undefined for it. Common real-world pattern: `hivTest` + `hivTestResult`, `art` + `artNumber`, etc.

**Practical effect on cloned rows (suffix ≥ 1):**

- Hide expressions silently evaluate incorrectly — follow-up fields disappear or appear when they shouldn't.
- Calculated values stop updating.
- `js_expression` validators don't fire, so invalid data can submit cleanly.
- No console error. Row 0 works fine, so it's easy to miss in smoke tests.

**Fix**

- Build one alternation regex over the field ids, sorted by length desc so longer ids are tried before their shorter prefixes.
- Escape regex metacharacters in ids before joining.
- Wrap the alternation in `\b...\b` so matches can't land inside a longer identifier.
- Single pass, no order dependence.

**Validation**

- Added a regression test in `repeat.test.ts` covering the substring-prefix case. Existing two tests still pass.
- Verified manually in the form-builder preview (linked against the local engine-lib) with a schema that has ids `test` and `testResult` and a hide expression referencing both. Before the fix, Row 1's follow-up field was permanently hidden; after the fix, Row 1 matches Row 0's behavior.

## Screenshots

### Before

https://github.com/user-attachments/assets/67a3416f-5bae-4590-855c-2556b2da31f8

### After

https://github.com/user-attachments/assets/92878e44-a7be-4a0a-b713-a2272865dedd

## Related Issue

None.

## Other

Found while validating adjacent findings to [openmrs-esm-form-engine-lib#726](https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/726).