### PR TITLE
(fix) Avoid suffix collision when adding a row after deleting a middle one

### DIFF
--- a/src/components/repeat/repeat.component.tsx
+++ b/src/components/repeat/repeat.component.tsx
@@ -1,15 +1,15 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { createErrorHandler } from '@openmrs/esm-framework';
 import type { FormField, FormFieldInputProps, RenderType } from '../../types';
+import { FormFieldRenderer } from '../renderer/field/form-field-renderer.component';
+import { clearSubmission, isViewMode } from '../../utils/common-utils';
+import { cloneRepeatField } from './helpers';
 import { evaluateAsyncExpression, evaluateExpression } from '../../utils/expression-runner';
 import { isEmpty } from '../../validators/form-validator';
-import styles from './repeat.scss';
-import { cloneRepeatField } from './helpers';
-import { clearSubmission, isViewMode } from '../../utils/common-utils';
-import RepeatControls from './repeat-controls.component';
-import { createErrorHandler } from '@openmrs/esm-framework';
-import { useFormProviderContext } from '../../provider/form-provider';
-import { FormFieldRenderer } from '../renderer/field/form-field-renderer.component';
 import { useFormFactory } from '../../provider/form-factory-provider';
+import { useFormProviderContext } from '../../provider/form-provider';
+import RepeatControls from './repeat-controls.component';
+import styles from './repeat.scss';
 
 const renderingByTypeMap: Record<string, RenderType> = {
   obsGroup: 'group',
@@ -18,7 +18,6 @@ const renderingByTypeMap: Record<string, RenderType> = {
 };
 
 const Repeat: React.FC<FormFieldInputProps> = ({ field }) => {
-  const [counter, setCounter] = useState(0);
   const [rows, setRows] = useState([]);
   const context = useFormProviderContext();
   const { handleConfirmQuestionDeletion } = useFormFactory();
@@ -42,7 +41,6 @@ const Repeat: React.FC<FormFieldInputProps> = ({ field }) => {
         _field.id.startsWith(field.id) &&
         !_field.meta?.repeat?.wasDeleted,
     );
-    setCounter(repeatedFields.length - 1);
     setRows(repeatedFields);
   }, [formFields, field]);
 
@@ -140,16 +138,16 @@ const Repeat: React.FC<FormFieldInputProps> = ({ field }) => {
   };
 
   const nodes = useMemo(() => {
-    return rows.map((field, index) => {
+    return rows.map((row, index) => {
       const component = (
         <FormFieldRenderer
-          fieldId={field.id}
-          valueAdapter={formFieldAdapters[field.type]}
-          repeatOptions={{ targetRendering: getQuestionWithSupportedRendering(field).questionOptions.rendering }}
+          fieldId={row.id}
+          valueAdapter={formFieldAdapters[row.type]}
+          repeatOptions={{ targetRendering: getQuestionWithSupportedRendering(row).questionOptions.rendering }}
         />
       );
       return (
-        <div key={field.id + '_wrapper'}>
+        <div key={row.id + '_wrapper'}>
           {index !== 0 && (
             <div>
               <hr className={styles.divider} />
@@ -158,16 +156,21 @@ const Repeat: React.FC<FormFieldInputProps> = ({ field }) => {
           <div className={styles.nodeContainer}>{component}</div>
           {!isViewMode(sessionMode) && (
             <RepeatControls
-              question={field}
+              question={row}
               rows={rows}
               questionIndex={index}
               handleDelete={() => {
-                onClickDeleteQuestion(field);
+                onClickDeleteQuestion(row);
               }}
               handleAdd={() => {
-                const nextCount = counter + 1;
-                handleAdd(nextCount);
-                setCounter(nextCount);
+                // Use max-existing-suffix + 1 so new rows don't collide with a surviving
+                // row after a middle row is deleted (the buggy `length - 1 + 1` would).
+                const nextSuffix =
+                  rows.reduce((max, r) => {
+                    const suffix = Number(r.id.slice(field.id.length + 1));
+                    return Number.isFinite(suffix) ? Math.max(max, suffix) : max;
+                  }, 0) + 1;
+                handleAdd(nextSuffix);
               }}
             />
           )}

--- a/src/form-engine.test.tsx
+++ b/src/form-engine.test.tsx
@@ -1140,6 +1140,41 @@ describe('Form engine component', () => {
         expect(femaleRadiosAfterReadd[1]).not.toBeChecked();
       });
     });
+
+    it('should assign unique ids to repeating rows after a middle row is deleted', async () => {
+      await act(async () => {
+        renderForm(null, obsGroupTestForm);
+      });
+
+      // Only the last row carries an Add button, so re-query it after every click.
+      // Add two more rows so we have 3 total (_0, _1, _2).
+      await user.click(screen.getByRole('button', { name: 'Add' }));
+      await waitFor(() => {
+        expect(screen.getAllByRole('radio', { name: /^male$/i })).toHaveLength(2);
+      });
+      await user.click(screen.getByRole('button', { name: 'Add' }));
+      await waitFor(() => {
+        expect(screen.getAllByRole('radio', { name: /^male$/i })).toHaveLength(3);
+      });
+
+      // Delete the middle row (_1). Only clones have Remove buttons, so there are 2.
+      const removeButtons = screen.getAllByRole('button', { name: /Remove/i });
+      expect(removeButtons).toHaveLength(2);
+      await user.click(removeButtons[0]);
+      await waitFor(() => {
+        expect(screen.getAllByRole('radio', { name: /^male$/i })).toHaveLength(2);
+      });
+
+      // Add a new row — its suffix must not collide with the surviving row (_2).
+      await user.click(screen.getByRole('button', { name: 'Add' }));
+      await new Promise((r) => setTimeout(r, 100));
+
+      const maleRadios = screen.getAllByRole('radio', { name: /^male$/i });
+      const ids = maleRadios.map((r) => r.id);
+      // Expect three rows, each with a unique childSex-Male input id.
+      expect(maleRadios).toHaveLength(3);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
   });
 
   describe('Read only mode', () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The Repeat component derived the next clone suffix from `counter = repeatedFields.length - 1` and Add used `counter + 1`. That's only safe when rows are a contiguous `[_0, _1, ..., _N]`. After a middle row is deleted — in edit mode (voided-branch `removeFormField` removes the field from `formFields`) or in a fresh session after Add/Add/Remove — the surviving indices have a hole, and `counter + 1` lands on an existing suffix.

**Reproducer (fresh form):** in a repeating obsGroup, Add a row, Add another row, then Remove the middle one and click Add. The new row is created with the same id as the surviving second row. React renders both (with a duplicate-key warning), and because both register under the same name, react-hook-form mirrors their values — typing in one updates the other. In edit mode the same thing happens when a clinician deletes a voided middle row and adds a new one.

**Fix**

- Compute the next suffix as `max(existing suffixes) + 1` from the rendered rows on each Add click, rather than tracking `counter` in state.
- Rename the `rows.map` iteration variable from `field` to `row` so it no longer shadows the component's outer `field` prop — the suffix computation needs to read the template's id.
- Remove the `counter` state and its `setCounter` call in the useEffect.

**Validation**

- Added a regression test in `form-engine.test.tsx` under the `Obs group` describe block: Add, Add, Remove middle, Add — asserts three rows with unique `childSex-Male` ids.
- Verified manually in the form-builder preview (linked against the local engine-lib) using a repeating obsGroup with a single text child (`contactName`). Before the fix: after Add/Add/Remove-middle/Add, two inputs both had `id="contactName_2"` and a shared value. After the fix: Alice / `contactName_2=Carol` / `contactName_3=""`.

## Screenshots

### Before

https://github.com/user-attachments/assets/9d915c54-9b4a-48c0-b18a-9b237551adc3

### After

https://github.com/user-attachments/assets/7be35623-fce2-4148-aca5-a1b647987e35

## Related Issue

None.

## Other

Follow-up to [#726](https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/726) (RHF state on clear-delete) and [#727](https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/727) (substring collision in expression id rewriting) — same component, different failure mode.