### PR TITLE
(feat) O3-4795: Show character counter when maxLength is set on textarea fields

### DIFF
--- a/src/components/inputs/text-area/text-area.component.tsx
+++ b/src/components/inputs/text-area/text-area.component.tsx
@@ -53,6 +53,10 @@ const TextArea: React.FC<FormFieldInputProps> = ({ field, value, errors, warning
             invalidText={errors[0]?.message}
             warn={warnings.length > 0}
             warnText={warnings[0]?.message}
+            enableCounter={!!(field.questionOptions.max || field.questionOptions.maxLength)}
+            maxCount={
+              field.questionOptions.max ? Number(field.questionOptions.max) : Number(field.questionOptions.maxLength)
+            }
           />
         </Layer>
       </div>

--- a/src/components/inputs/text-area/text-area.test.tsx
+++ b/src/components/inputs/text-area/text-area.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { type FetchResponse, openmrsFetch, usePatient, useSession } from '@openmrs/esm-framework';
+import { mockSessionDataResponse } from '__mocks__/session.mock';
+import { mockPatient } from '__mocks__/patient.mock';
+import { mockVisit } from '__mocks__/visit.mock';
+import { useFormProviderContext } from 'src/provider/form-provider';
+import { sampleFieldsForm } from '__mocks__/forms';
+import TextArea from './text-area.component';
+
+const mockOpenmrsFetch = jest.mocked(openmrsFetch);
+const mockUseSession = jest.mocked(useSession);
+const mockUsePatient = jest.mocked(usePatient);
+const mockSetFieldValue = jest.fn();
+
+jest.mock('../../../api', () => {
+  const originalModule = jest.requireActual('../../../api');
+
+  return {
+    ...originalModule,
+    getPreviousEncounter: jest.fn().mockImplementation(() => Promise.resolve(null)),
+  };
+});
+
+jest.mock('src/provider/form-provider', () => ({
+  useFormProviderContext: jest.fn(),
+}));
+
+const mockUseFormProviderContext = useFormProviderContext as jest.Mock;
+
+const textAreaValues = {
+  field: {
+    label: 'Clinical notes',
+    type: 'obs',
+    required: false,
+    id: 'clinicalNotes',
+    questionOptions: {
+      rendering: 'textarea',
+      concept: '160632AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      answers: [],
+    },
+    meta: {
+      submission: {
+        newValue: null,
+      },
+      concept: {
+        uuid: '160632AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        display: 'Free text general',
+        conceptClass: {
+          uuid: '8d491e50-c2cc-11de-8d13-0010c6dffd0f',
+          display: 'Question',
+        },
+        answers: [],
+        conceptMappings: [],
+      },
+    },
+    validators: [{ type: 'form_field' }, { type: 'default_value' }],
+    isHidden: false,
+    isRequired: false,
+    isDisabled: false,
+  },
+  value: null,
+  errors: [],
+  warnings: [],
+  setFieldValue: mockSetFieldValue,
+};
+
+const renderForm = async (props) => {
+  await act(() => render(<TextArea {...props} />));
+};
+
+let formProcessor;
+
+const mockProviderValues = {
+  layoutType: 'small-desktop',
+  sessionMode: 'enter',
+  workspaceLayout: 'minimized',
+  formFieldAdapters: {},
+  patient: mockPatient,
+  methods: undefined,
+  formJson: sampleFieldsForm,
+  visit: mockVisit,
+  sessionDate: new Date(),
+  location: mockVisit.location,
+  currentProvider: mockVisit.encounters[0]?.encounterProvider,
+  processor: formProcessor,
+};
+
+describe('TextArea field input', () => {
+  beforeEach(() => {
+    formProcessor = { getInitialValues: jest.fn() };
+    mockOpenmrsFetch.mockResolvedValue({
+      data: { results: [{ ...sampleFieldsForm }] },
+    } as unknown as FetchResponse);
+    mockUseSession.mockReturnValue(mockSessionDataResponse.data);
+    mockUsePatient.mockReturnValue({
+      isLoading: false,
+      patient: mockPatient,
+      patientUuid: mockPatient.id,
+      error: null,
+    });
+    mockUseFormProviderContext.mockReturnValue({
+      ...mockProviderValues,
+      setFieldValue: mockSetFieldValue,
+    });
+  });
+
+  it('should have value passed in as prop', async () => {
+    await renderForm({ ...textAreaValues, value: 'Initial clinical notes' });
+    const inputField = screen.getByLabelText('Clinical notes');
+    expect(inputField).toHaveValue('Initial clinical notes');
+  });
+
+  it('should disable field', async () => {
+    await renderForm({
+      ...textAreaValues,
+      field: { ...textAreaValues.field, isDisabled: true },
+    });
+    const inputField = screen.getByLabelText('Clinical notes');
+    expect(inputField).toBeDisabled();
+  });
+
+  it('should show character counter when maxLength is set', async () => {
+    await renderForm({
+      ...textAreaValues,
+      field: {
+        ...textAreaValues.field,
+        questionOptions: { ...textAreaValues.field.questionOptions, maxLength: 500 },
+      },
+    });
+    expect(screen.getByText('0/500')).toBeInTheDocument();
+  });
+
+  it('should not show character counter when maxLength is not set', async () => {
+    await renderForm(textAreaValues);
+    expect(screen.queryByText(/\/\d+/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

Sibling fix to #725 — extends the same character counter wiring to `text-area.component.tsx`.

Carbon's `TextArea` supports `enableCounter` and `maxCount` props but they were not being passed, so the counter never rendered even when `maxLength` was set in `questionOptions`. This PR adds both props using the same conditional logic introduced for the `TextInput` fix.

Also adds a `text-area.test.tsx` covering the counter-shown and counter-hidden branches, plus baseline value and disabled-field cases.

## Screenshots

<!-- Add screenshots or screen recordings for UI changes -->

## Related Issue

Follows from denniskigen's review on #725.

Tickets: [O3-4795](https://openmrs.atlassian.net/browse/O3-4795) | [O3-5625](https://openmrs.atlassian.net/browse/O3-5625)

## Other

N/A

[O3-4795]: https://openmrs.atlassian.net/browse/O3-4795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ