### PR TITLE
(feat) Expand markdown allowlist for richer explanatory content

### DIFF
--- a/src/components/inputs/markdown/markdown-wrapper.component.tsx
+++ b/src/components/inputs/markdown/markdown-wrapper.component.tsx
@@ -1,13 +1,35 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
+import styles from './markdown-wrapper.scss';
 
 const MarkdownWrapper: React.FC<{ markdown: string }> = ({ markdown }) => {
   return (
-    <ReactMarkdown
-      children={markdown}
-      unwrapDisallowed={true}
-      allowedElements={['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'strong', 'em']}
-    />
+    <div className={styles.markdownWrapper}>
+      <ReactMarkdown
+        children={markdown}
+        unwrapDisallowed={true}
+        allowedElements={[
+          'h1',
+          'h2',
+          'h3',
+          'h4',
+          'h5',
+          'h6',
+          'p',
+          'strong',
+          'em',
+          'code',
+          'pre',
+          'ul',
+          'ol',
+          'li',
+          'a',
+          'blockquote',
+          'hr',
+          'br',
+        ]}
+      />
+    </div>
   );
 };
 

--- a/src/components/inputs/markdown/markdown-wrapper.component.tsx
+++ b/src/components/inputs/markdown/markdown-wrapper.component.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { type Components } from 'react-markdown';
 import styles from './markdown-wrapper.scss';
+
+const components: Components = {
+  a: ({ node, ...props }) => <a {...props} target="_blank" rel="noopener noreferrer" referrerPolicy="no-referrer" />,
+};
 
 const MarkdownWrapper: React.FC<{ markdown: string }> = ({ markdown }) => {
   return (
@@ -28,6 +32,7 @@ const MarkdownWrapper: React.FC<{ markdown: string }> = ({ markdown }) => {
           'hr',
           'br',
         ]}
+        components={components}
       />
     </div>
   );

--- a/src/components/inputs/markdown/markdown-wrapper.scss
+++ b/src/components/inputs/markdown/markdown-wrapper.scss
@@ -1,0 +1,60 @@
+@use '@carbon/colors';
+@use '@carbon/layout';
+
+.markdownWrapper {
+  ul,
+  ol {
+    margin: layout.$spacing-03 0 layout.$spacing-03 layout.$spacing-06;
+  }
+
+  ul {
+    list-style: disc;
+  }
+
+  ol {
+    list-style: decimal;
+  }
+
+  li {
+    margin-bottom: layout.$spacing-02;
+  }
+
+  blockquote {
+    margin: layout.$spacing-03 0;
+    padding: layout.$spacing-02 layout.$spacing-04;
+    border-left: 3px solid colors.$gray-30;
+    color: colors.$gray-70;
+  }
+
+  pre {
+    margin: layout.$spacing-03 0;
+    padding: layout.$spacing-03;
+    background: colors.$gray-10;
+    border-radius: 4px;
+    overflow-x: auto;
+
+    code {
+      background: none;
+      padding: 0;
+    }
+  }
+
+  code {
+    background: colors.$gray-10;
+    padding: 0 layout.$spacing-02;
+    border-radius: 2px;
+    font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.875em;
+  }
+
+  hr {
+    margin: layout.$spacing-04 0;
+    border: 0;
+    border-top: 1px solid colors.$gray-30;
+  }
+
+  a {
+    color: colors.$blue-60;
+    text-decoration: underline;
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary

The markdown question type currently renders a fixed allowlist of `h1..h6, p, strong, em` with `unwrapDisallowed: true`, so any other element a form author writes (inline code, fenced code blocks, lists, links, blockquotes, horizontal rules, line breaks) is silently stripped to flat prose. #411 set out to expand this list, but the merged code kept the original minimal set, so the change never landed.

This PR finishes that work:

- Expands the allowlist to also accept `code`, `pre`, `ul`, `ol`, `li`, `a`, `blockquote`, `hr`, `br`.
- Adds a small SCSS module (`markdown-wrapper.scss`) that restores list markers, blockquote indent, monospace styling for inline and block code, `<hr>` spacing, and link colour. Carbon's resets zero out the browser defaults, so the elements were rendering but appeared unstyled without explicit rules.

This unblocks authors who use the markdown question type to document patterns or surface clinical guidance: a JSON snippet, a bulleted list of options, or a link to a reference can now be rendered as written.

### Safety

`react-markdown` does not allow raw HTML (the project explicitly removed `rehype-raw` in #411), so the expanded allowlist only governs elements produced by markdown syntax itself. URL-bearing elements remain sanitised by `react-markdown`'s default `urlTransform`. No `<script>`, `<iframe>`, `<style>`, or other dangerous tags can slip through pure markdown source.

Tables are intentionally not added: they require `remark-gfm`, which was deliberately removed in #411.

## Screenshots

A small smoke-test schema covering every newly allowed element (headings, inline and fenced code, bulleted and numbered lists, link, blockquote, horizontal rule) renders as expected against this branch:

<img width="3364" height="1932" alt="CleanShot 2026-04-28 at 23 05 54@2x" src="https://github.com/user-attachments/assets/72973439-a0df-452e-a907-a4c3a5ff453a" />


## Related Issue

Continues the work started in #411.

## Other

The smoke-test schema used to verify the rendering, for reviewers who want to reproduce locally:

```json
{
  "name": "Markdown Allowlist Smoke Test",
  "version": "1",
  "published": false,
  "encounter": "Consultation",
  "processor": "EncounterFormProcessor",
  "pages": [
    {
      "label": "Markdown",
      "sections": [
        {
          "label": "All elements",
          "isExpanded": "true",
          "questions": [
            {
              "id": "smokeIntro",
              "questionOptions": { "rendering": "markdown" },
              "value": [
                "## Heading 2\n\n### Heading 3\n\nA paragraph with **bold**, *italic*, and `inline code`.\n\n```json\n{ \"hide\": { \"hideWhenExpression\": \"isEmpty(answer)\" } }\n```\n\n- bulleted item with `code`\n- second item\n\n1. first\n2. second\n\nA [link](https://openmrs.org).\n\n> A blockquote.\n\n---\n\nAfter the rule."
              ]
            }
          ]
        }
      ]
    }
  ]
}
```