### PR TITLE
(feat) O3-4607: Update getLatestObs to Support Multi-Checkbox Observations

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -77,13 +77,34 @@ export async function getLatestObs(
   conceptUuid: string,
   encounterTypeUuid?: string,
 ): Promise<FHIRObsResource> {
-  let params = `patient=${patientUuid}&code=${conceptUuid}${
-    encounterTypeUuid ? `&encounter.type=${encounterTypeUuid}` : ''
-  }`;
+  let params = `patient=${patientUuid}&code=${conceptUuid}${encounterTypeUuid ? `&encounter.type=${encounterTypeUuid}` : ''
+    }`;
   // the latest obs
   params += '&_sort=-date&_count=1';
   const { data } = await openmrsFetch(`${fhirBaseUrl}/Observation?${params}`);
   return data.entry?.length ? data.entry[0].resource : null;
+}
+
+export async function getLatestObsForConceptSet(
+  patientUuid: string,
+  conceptUuid: string,
+  encounterTypeUuid?: string,
+): Promise<FHIRObsResource[]> {
+  // First, find the single latest obs to identify the encounter
+  const latestObs = await getLatestObs(patientUuid, conceptUuid, encounterTypeUuid);
+  if (!latestObs) {
+    return [];
+  }
+
+  const encounterId = latestObs.encounter?.reference?.split('/').pop();
+  if (!encounterId) {
+    return [latestObs];
+  }
+
+  // Fetch ALL obs for that concept within the same encounter
+  const params = `patient=${patientUuid}&code=${conceptUuid}&encounter=${encounterId}`;
+  const { data } = await openmrsFetch(`${fhirBaseUrl}/Observation?${params}`);
+  return data.entry?.map((e) => e.resource) ?? [];
 }
 
 /**

--- a/src/form-engine.test.tsx
+++ b/src/form-engine.test.tsx
@@ -132,6 +132,7 @@ jest.mock('../src/api', () => {
     getPreviousEncounter: jest.fn().mockImplementation(() => Promise.resolve(mockHxpEncounter)),
     getConcept: jest.fn().mockImplementation(() => Promise.resolve(null)),
     getLatestObs: jest.fn().mockImplementation(() => Promise.resolve({ valueNumeric: 60 })),
+    getLatestObsForConceptSet: jest.fn().mockImplementation(() => Promise.resolve([{ valueNumeric: 60 }])),
     saveEncounter: jest.fn().mockImplementation(() => Promise.resolve(mockSaveEncounter)),
     createProgramEnrollment: jest.fn(),
   };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary

Adds a new `getLatestObsForConceptSet` helper function that returns all observations for a given concept from the latest relevant encounter, supporting multi-checkbox inputs that create multiple obs with the same concept UUID.

## Approach
- Added `getLatestObsForConceptSet()` in `src/api/index.ts`
- It reuses `getLatestObs` to find the latest encounter, then fetches all obs
  for that concept within that encounter
- The existing `getLatestObs` function is unchanged (single-resource contract preserved)
- No changes needed in `common-expression-helpers.ts` since it already imports
  all exports from the API module via `import * as apiFunctions`
- Updated test mocks in `form-engine.test.tsx`

## How to test
Schema authors can now use `api.getLatestObsForConceptSet(patientUuid, conceptUuid, encounterTypeUuid?)`
in `historicalExpression` to retrieve the full set of checkbox values from the latest encounter.

## Related Issue
https://openmrs.atlassian.net/browse/O3-4607

## Screenshots
<!-- Required if you are making UI changes. -->

## Other
<!-- Anything not covered above -->
