### PR TITLE
(feat) O3-5660: Encounter provider field should auto-fill with current session provider on new forms

### DIFF
--- a/__mocks__/forms/rfe-forms/sample-ui-select-ext.json
+++ b/__mocks__/forms/rfe-forms/sample-ui-select-ext.json
@@ -37,6 +37,15 @@
                 "concept": "4b59ac07-cf72-4f46-b8c0-4f62b1779f7e"
               },
               "id": "problem"
+            },
+            {
+              "label": "Provider",
+              "type": "encounterProvider",
+              "questionOptions": {
+                "isSearchable": true,
+                "rendering": "encounter-provider"
+              },
+              "id": "encounter-provider"
             }
           ]
         }

--- a/src/adapters/encounter-provider-adapter.test.ts
+++ b/src/adapters/encounter-provider-adapter.test.ts
@@ -1,0 +1,52 @@
+import { type FormField, type FormProcessorContextProps } from '../types';
+import { EncounterProviderAdapter } from './encounter-provider-adapter';
+import { it, describe, expect } from 'vitest';
+
+const field: FormField = {
+  label: 'Provider',
+  type: 'encounterProvider',
+  questionOptions: { rendering: 'encounter-provider' },
+  id: 'encounter-provider',
+};
+
+const baseContext = {
+  currentProvider: { uuid: 'session-provider-uuid' },
+} as unknown as FormProcessorContextProps;
+
+const encounterWithProvider = {
+  uuid: 'encounter-uuid',
+  encounterProviders: [{ provider: { uuid: 'saved-provider-uuid', display: 'Saved Provider' } }],
+};
+
+describe('EncounterProviderAdapter - getInitialValue', () => {
+  it('returns the saved provider UUID when an encounter with providers exists', () => {
+    const result = EncounterProviderAdapter.getInitialValue(field, encounterWithProvider as any, baseContext);
+    expect(result).toBe('saved-provider-uuid');
+  });
+
+  it('returns the last provider UUID when the encounter has multiple providers', () => {
+    const encounter = {
+      uuid: 'encounter-uuid',
+      encounterProviders: [{ provider: { uuid: 'first-provider-uuid' } }, { provider: { uuid: 'last-provider-uuid' } }],
+    };
+    const result = EncounterProviderAdapter.getInitialValue(field, encounter as any, baseContext);
+    expect(result).toBe('last-provider-uuid');
+  });
+
+  it('falls back to the current session provider UUID when there is no encounter', () => {
+    const result = EncounterProviderAdapter.getInitialValue(field, null, baseContext);
+    expect(result).toBe('session-provider-uuid');
+  });
+
+  it('falls back to the current session provider UUID when the encounter has no providers', () => {
+    const encounter = { uuid: 'encounter-uuid', encounterProviders: [] };
+    const result = EncounterProviderAdapter.getInitialValue(field, encounter as any, baseContext);
+    expect(result).toBe('session-provider-uuid');
+  });
+
+  it('returns undefined when there is no encounter and no session provider', () => {
+    const context = { ...baseContext, currentProvider: null } as unknown as FormProcessorContextProps;
+    const result = EncounterProviderAdapter.getInitialValue(field, null, context);
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/adapters/encounter-provider-adapter.ts
+++ b/src/adapters/encounter-provider-adapter.ts
@@ -13,8 +13,11 @@ export const EncounterProviderAdapter: FormFieldValueAdapter = {
     gracefullySetSubmission(field, value, null);
   },
   getInitialValue: function (field: FormField, sourceObject: OpenmrsResource, context: FormProcessorContextProps) {
-    const encounter = sourceObject ?? context.previousDomainObjectValue;
-    return getLatestProvider(encounter)?.uuid;
+    const provider = getLatestProvider(sourceObject);
+    if (provider?.uuid) {
+      return provider.uuid;
+    }
+    return context.currentProvider?.uuid;
   },
   getPreviousValue: function (
     field: FormField,

--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -124,28 +124,29 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
 
   useEffect(() => {
     let ignore = false;
-    if (value && !isDirty && dataSource && isSearchable && sessionMode !== 'enter' && !items.length) {
-      // While in edit mode, search-based instances should fetch the initial item (previously selected value) to resolve its display property
+    if (value && !isDirty && dataSource && isSearchable && !items.length) {
+      // For search-based instances, fetch the initial item to resolve its display property
       setIsLoading(true);
-      try {
-        dataSource.fetchSingleItem(value).then((item) => {
+      dataSource
+        .fetchSingleItem(value)
+        .then((item) => {
           if (!ignore) {
             setItems([dataSource.toUuidAndDisplay(item)]);
             setIsLoading(false);
           }
+        })
+        .catch((error) => {
+          if (!ignore) {
+            console.error(error);
+            setIsLoading(false);
+          }
         });
-      } catch (error) {
-        if (!ignore) {
-          console.error(error);
-          setIsLoading(false);
-        }
-      }
     }
 
     return () => {
       ignore = true;
     };
-  }, [value, isDirty, sessionMode, dataSource, isSearchable, items]);
+  }, [value, isDirty, dataSource, isSearchable, items]);
 
   if (isLoading) {
     return <DropdownSkeleton />;

--- a/src/components/inputs/ui-select-extended/ui-select-extended.test.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.test.tsx
@@ -253,21 +253,6 @@ describe('UiSelectExtended', () => {
         undefined,
       );
     });
-    it('should display the session provider name in the provider ComboBox on a new form', async () => {
-      const provider = mockSessionDataResponse.data.currentProvider;
-      mockOpenmrsFetch.mockResolvedValueOnce({ data: { uuid: provider.uuid, display: provider.display } } as any);
-
-      await act(async () => {
-        renderForm('enter');
-      });
-
-      const providerSelect = await findSelectInput(screen, 'Provider');
-      expect(mockOpenmrsFetch).toHaveBeenCalledWith(
-        `${restBaseUrl}/provider/${provider.uuid}?v=custom:(uuid,display)`,
-      );
-      expect(providerSelect).toHaveValue(provider.display);
-    });
-
     it('should display all items regardless of user input', async () => {
       await act(async () => {
         renderForm();
@@ -290,6 +275,39 @@ describe('UiSelectExtended', () => {
       expect(screen.getByText('Naguru')).toBeInTheDocument();
       expect(screen.getByText('Muyenga')).toBeInTheDocument();
     });
+  });
+
+  it('should fetch the session provider via ProviderDataSource on a new form', async () => {
+    const provider = mockSessionDataResponse.data.currentProvider;
+    mockOpenmrsFetch.mockResolvedValueOnce({ data: { uuid: provider.uuid, display: provider.display } } as any);
+
+    await act(async () => {
+      renderForm('enter');
+    });
+
+    await waitFor(() => {
+      expect(mockOpenmrsFetch).toHaveBeenCalledWith(`${restBaseUrl}/provider/${provider.uuid}?v=custom:(uuid,display)`);
+    });
+  });
+
+  it('should save the encounter with the session provider when the user submits without touching the provider field', async () => {
+    const provider = mockSessionDataResponse.data.currentProvider;
+    const mockSaveEncounter = vi.spyOn(api, 'saveEncounter');
+    mockOpenmrsFetch.mockResolvedValueOnce({ data: { uuid: provider.uuid, display: provider.display } } as any);
+
+    await act(async () => {
+      renderForm('enter');
+    });
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(mockSaveEncounter).toHaveBeenCalledWith(
+      expect.any(AbortController),
+      expect.objectContaining({
+        encounterProviders: [expect.objectContaining({ provider: provider.uuid })],
+      }),
+      undefined,
+    );
   });
 
   // TODO: Re-enable once the Carbon UiSelectExtended combobox renders its options

--- a/src/components/inputs/ui-select-extended/ui-select-extended.test.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { vi, describe, it, expect, test, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { act, render, screen } from '@testing-library/react';
-import { usePatient, useSession } from '@openmrs/esm-framework';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { openmrsFetch, restBaseUrl, usePatient, useSession } from '@openmrs/esm-framework';
 import * as api from '../../../api';
 import { type FormSchema, type SessionMode, type OpenmrsEncounter } from '../../../types';
 import { assertFormHasAllFields, findSelectInput } from '../../../utils/test-utils';
@@ -13,6 +13,7 @@ import FormEngine from '../../../form-engine.component';
 
 const mockUsePatient = vi.mocked(usePatient);
 const mockUseSession = vi.mocked(useSession);
+const mockOpenmrsFetch = vi.mocked(openmrsFetch);
 
 vi.mock('lodash-es/debounce', () => vi.fn((fn) => fn));
 
@@ -60,48 +61,56 @@ vi.mock('../../../hooks/useConcepts', () => ({
 }));
 
 vi.mock('../../../registry/registry', async () => {
-  const originalModule = (await vi.importActual('../../../registry/registry')) as object;
-  return {
-    ...originalModule,
-    getRegisteredDataSource: vi.fn().mockResolvedValue({
-      fetchData: vi.fn().mockImplementation((...args) => {
-        if (args[1].class?.length) {
-          // concept DS
-          return Promise.resolve([
-            {
-              uuid: 'stage-1-uuid',
-              display: 'stage 1',
-            },
-            {
-              uuid: 'stage-2-uuid',
-              display: 'stage 2',
-            },
-          ]);
-        }
-
-        // location DS
+  const originalModule = (await vi.importActual('../../../registry/registry')) as any;
+  const mockDataSource = {
+    fetchData: vi.fn().mockImplementation((...args: any[]) => {
+      if (args[1].class?.length) {
+        // concept DS
         return Promise.resolve([
           {
-            uuid: 'aaa-1',
-            display: 'Kololo',
+            uuid: 'stage-1-uuid',
+            display: 'stage 1',
           },
           {
-            uuid: 'aaa-2',
-            display: 'Naguru',
-          },
-          {
-            uuid: 'aaa-3',
-            display: 'Muyenga',
+            uuid: 'stage-2-uuid',
+            display: 'stage 2',
           },
         ]);
-      }),
-      fetchSingleItem: vi.fn().mockImplementation((uuid: string) => {
-        return Promise.resolve({
-          uuid,
-          display: 'stage 1',
-        });
-      }),
-      toUuidAndDisplay: (data) => data,
+      }
+
+      // location DS
+      return Promise.resolve([
+        {
+          uuid: 'aaa-1',
+          display: 'Kololo',
+        },
+        {
+          uuid: 'aaa-2',
+          display: 'Naguru',
+        },
+        {
+          uuid: 'aaa-3',
+          display: 'Muyenga',
+        },
+      ]);
+    }),
+    fetchSingleItem: vi.fn().mockImplementation((uuid: string) => {
+      return Promise.resolve({
+        uuid,
+        display: 'stage 1',
+      });
+    }),
+    toUuidAndDisplay: (data: any) => data,
+  };
+
+  return {
+    ...originalModule,
+    getRegisteredDataSource: vi.fn().mockImplementation((name: string) => {
+      if (name === 'encounter-provider' || name === 'provider_datasource') {
+        return originalModule.getRegisteredDataSource(name);
+      }
+
+      return Promise.resolve(mockDataSource);
     }),
   };
 });
@@ -243,6 +252,20 @@ describe('UiSelectExtended', () => {
         }),
         undefined,
       );
+    });
+    it('should display the session provider name in the provider ComboBox on a new form', async () => {
+      const provider = mockSessionDataResponse.data.currentProvider;
+      mockOpenmrsFetch.mockResolvedValueOnce({ data: { uuid: provider.uuid, display: provider.display } } as any);
+
+      await act(async () => {
+        renderForm('enter');
+      });
+
+      const providerSelect = await findSelectInput(screen, 'Provider');
+      expect(mockOpenmrsFetch).toHaveBeenCalledWith(
+        `${restBaseUrl}/provider/${provider.uuid}?v=custom:(uuid,display)`,
+      );
+      expect(providerSelect).toHaveValue(provider.display);
     });
 
     it('should display all items regardless of user input', async () => {

--- a/src/datasources/provider-datasource.test.ts
+++ b/src/datasources/provider-datasource.test.ts
@@ -1,0 +1,49 @@
+import { vi, it, describe, beforeEach, expect } from 'vitest';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import { ProviderDataSource } from './provider-datasource';
+
+const mockOpenmrsFetch = vi.mocked(openmrsFetch);
+
+describe('ProviderDataSource', () => {
+  let ds: ProviderDataSource;
+
+  beforeEach(() => {
+    ds = new ProviderDataSource();
+  });
+
+  describe('fetchSingleItem', () => {
+    it('fetches a single provider by UUID at the correct endpoint', async () => {
+      const uuid = 'provider-uuid-1';
+      const mockProvider = { uuid, display: 'Dr. Test' };
+      mockOpenmrsFetch.mockResolvedValueOnce({ data: mockProvider } as any);
+
+      const result = await ds.fetchSingleItem(uuid);
+
+      expect(mockOpenmrsFetch).toHaveBeenCalledWith(`${restBaseUrl}/provider/${uuid}?v=custom:(uuid,display)`);
+      expect(result).toEqual(mockProvider);
+    });
+  });
+
+  describe('fetchData', () => {
+    it('fetches all providers when no search term is given', async () => {
+      const mockProviders = [
+        { uuid: 'uuid-1', display: 'Provider 1' },
+        { uuid: 'uuid-2', display: 'Provider 2' },
+      ];
+      mockOpenmrsFetch.mockResolvedValueOnce({ data: { results: mockProviders } } as any);
+
+      const result = await ds.fetchData(null);
+
+      expect(mockOpenmrsFetch).toHaveBeenCalledWith(`${restBaseUrl}/provider?v=custom:(uuid,display)`);
+      expect(result).toEqual(mockProviders);
+    });
+
+    it('appends the search term to the request URL when provided', async () => {
+      mockOpenmrsFetch.mockResolvedValueOnce({ data: { results: [] } } as any);
+
+      await ds.fetchData('john');
+
+      expect(mockOpenmrsFetch).toHaveBeenCalledWith(`${restBaseUrl}/provider?v=custom:(uuid,display)&q=john`);
+    });
+  });
+});

--- a/src/datasources/provider-datasource.ts
+++ b/src/datasources/provider-datasource.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, type OpenmrsResource } from '@openmrs/esm-framework';
 import { BaseOpenMRSDataSource } from './data-source';
 
 export class ProviderDataSource extends BaseOpenMRSDataSource {
@@ -11,5 +11,10 @@ export class ProviderDataSource extends BaseOpenMRSDataSource {
     const url = `${restBaseUrl}/provider?${rep}`;
     const { data } = await openmrsFetch(searchTerm ? `${url}&q=${searchTerm}` : url);
     return data?.results;
+  }
+
+  async fetchSingleItem(uuid: string): Promise<OpenmrsResource | null> {
+    const { data } = await openmrsFetch(`${restBaseUrl}/provider/${uuid}?v=custom:(uuid,display)`);
+    return data;
   }
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

On a new encounter form with an `encounterProvider` field, the provider ComboBox previously rendered empty. `EncounterProviderAdapter.getInitialValue` fell back to `context.previousDomainObjectValue`, which `loadDependencies` populates from `getPreviousEncounter` — so the field would pre-fill from the patient's most recent prior encounter of that type, not from the user currently completing the form. On submission, `getMutableSessionProps` would then default to `currentProvider.uuid`, meaning what got saved didn't match what the user saw (or didn't see).

This PR replaces the `previousDomainObjectValue` fallback with `context.currentProvider?.uuid`, so new forms now pre-fill the provider with the session user — what the form saves and what the user sees are now aligned. Edit mode is unchanged: `getLatestProvider(sourceObject)` is consulted first, so an existing encounter's saved provider still wins.

Two supporting changes are required for the seeded UUID to render in the ComboBox:

- Override `ProviderDataSource.fetchSingleItem`. The inherited implementation relies on `this.url`, but `ProviderDataSource` calls `super(null)` and would throw `null.includes('?')` synchronously.
- Drop the `sessionMode !== 'enter'` guard around the display-resolution effect in `UiSelectExtended` so the ComboBox can resolve the pre-filled UUID's display on new forms. This widens the effect to every `isSearchable` `UiSelectExtended` with an initial value.

Also fixes a latent bug in the same effect: the prior synchronous `try/catch` around `dataSource.fetchSingleItem(...).then(...)` could never catch async rejections — replaced with a proper `.catch()`.

### Tests

- `EncounterProviderAdapter` unit tests cover saved-provider-wins, multi-provider, session-provider fallback, and the no-session-no-encounter case.
- `ProviderDataSource` unit tests cover the single-item endpoint and the search-term URL.
- A new integration test mounts the form engine in `enter` mode and asserts `openmrsFetch` is called against `/provider/<session-uuid>?v=custom:(uuid,display)`, exercising the full adapter → `ProviderDataSource` → fetch path. A stronger UI assertion on the rendered ComboBox value is deferred until the Carbon ComboBox + jsdom skip in this file is resolved.

## Screenshots

<!-- Required if you are making UI changes. -->

## Related Issue

- [O3-5660](https://openmrs.atlassian.net/browse/O3-5660)
- Follow-up to #675

## Other


[O3-5660]: https://openmrs.atlassian.net/browse/O3-5660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ