### PR TITLE
(fix) O3-5735: Keep default encounter datetimes within the visit window during retrospective data entry

### DIFF
--- a/src/form-engine.component.tsx
+++ b/src/form-engine.component.tsx
@@ -8,6 +8,7 @@ import { init, teardown } from './lifecycle';
 import { isEmpty, useFormJson } from '.';
 import { formEngineAppName } from './globals';
 import { reportError } from './utils/error-utils';
+import { getDateWithinVisitWindow } from './utils/common-utils';
 import { useFormCollapse } from './hooks/useFormCollapse';
 import { useFormWorkspaceSize } from './hooks/useFormWorkspaceSize';
 import { usePageObserver } from './components/sidebar/usePageObserver';
@@ -58,9 +59,12 @@ const FormEngine = ({
   const { t } = useTranslation();
   const session = useSession();
   const ref = useRef(null);
+  const rawSessionDate = useRef(new Date());
+  // Recompute when the visit bounds arrive or change; the visit prop may not be
+  // fully loaded when the form mounts.
   const sessionDate = useMemo(() => {
-    return new Date();
-  }, []);
+    return getDateWithinVisitWindow(rawSessionDate.current, visit);
+  }, [visit?.startDatetime, visit?.stopDatetime]);
   const workspaceSize = useFormWorkspaceSize(ref);
   const { patient, isLoadingPatient } = usePatientData(patientUUID);
   const [isLoadingDependencies, setIsLoadingDependencies] = useState(false);

--- a/src/processors/encounter/encounter-processor-helper.test.ts
+++ b/src/processors/encounter/encounter-processor-helper.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { getMutableSessionProps } from './encounter-processor-helper';
+import { type FormContextProps } from '../../provider/form-provider';
+import { type FormField } from '../../types';
+
+describe('getMutableSessionProps', () => {
+  const sessionDate = new Date('2026-06-10T17:00:00.000Z');
+
+  const buildContext = (overrides: Record<string, unknown> = {}) =>
+    ({
+      formFields: [],
+      location: { uuid: 'session-location-uuid' },
+      currentProvider: { uuid: 'current-provider-uuid' },
+      customDependencies: { defaultEncounterRole: { uuid: 'default-role-uuid' } },
+      sessionDate,
+      domainObjectValue: null,
+      ...overrides,
+    } as unknown as FormContextProps);
+
+  it('should use the encounterDatetime field submission value when present', () => {
+    const explicitDate = new Date('2026-06-10T10:30:00.000Z');
+    const context = buildContext({
+      formFields: [
+        {
+          id: 'encDate',
+          type: 'encounterDatetime',
+          questionOptions: { rendering: 'datetime' },
+          meta: { submission: { newValue: explicitDate } },
+        } as unknown as FormField,
+      ],
+    });
+
+    expect(getMutableSessionProps(context).encounterDate).toEqual(explicitDate);
+  });
+
+  it('should fall back to the session date for new encounters so the backend does not default to "now"', () => {
+    const context = buildContext();
+
+    expect(getMutableSessionProps(context).encounterDate).toEqual(sessionDate);
+  });
+
+  it('should preserve the existing encounter datetime when editing without changing the date', () => {
+    const context = buildContext({
+      domainObjectValue: {
+        uuid: 'encounter-uuid',
+        encounterDatetime: '2026-06-01T10:00:00.000Z',
+        location: { uuid: 'encounter-location-uuid' },
+      },
+    });
+
+    expect(getMutableSessionProps(context).encounterDate).toEqual(new Date('2026-06-01T10:00:00.000Z'));
+  });
+});

--- a/src/processors/encounter/encounter-processor-helper.ts
+++ b/src/processors/encounter/encounter-processor-helper.ts
@@ -172,13 +172,26 @@ export function saveAttachments(fields: FormField[], encounter: OpenmrsEncounter
 }
 
 export function getMutableSessionProps(context: FormContextProps) {
-  const { formFields, location, currentProvider, customDependencies, domainObjectValue: encounter } = context;
+  const {
+    formFields,
+    location,
+    currentProvider,
+    customDependencies,
+    sessionDate,
+    domainObjectValue: encounter,
+  } = context;
   const { defaultEncounterRole } = customDependencies;
   const encounterRole =
     formFields.find((field) => field.type === 'encounterRole')?.meta.submission?.newValue || defaultEncounterRole?.uuid;
   const encounterProvider =
     formFields.find((field) => field.type === 'encounterProvider')?.meta.submission?.newValue || currentProvider.uuid;
-  const encounterDate = formFields.find((field) => field.type === 'encounterDatetime')?.meta.submission?.newValue;
+  const explicitEncounterDate = formFields.find((field) => field.type === 'encounterDatetime')?.meta.submission
+    ?.newValue;
+  // Always submit an explicit datetime for new encounters; if it is omitted, the backend
+  // defaults it to "now", which fails validation when saving into a past (stopped) visit.
+  // `sessionDate` is already constrained to the visit window.
+  const encounterDate =
+    explicitEncounterDate ?? (encounter?.encounterDatetime ? new Date(encounter.encounterDatetime) : sessionDate);
   const encounterLocation =
     formFields.find((field) => field.type === 'encounterLocation')?.meta.submission?.newValue ||
     encounter?.location?.uuid ||

--- a/src/utils/common-utils.test.ts
+++ b/src/utils/common-utils.test.ts
@@ -1,12 +1,14 @@
 import {
   clearSubmission,
   flattenObsList,
+  getDateWithinVisitWindow,
   gracefullySetSubmission,
   hasRendering,
   hasSubmission,
   parseToLocalDateTime,
 } from './common-utils';
 import { vi, describe, it, expect, type Mock } from 'vitest';
+import { type Visit } from '@openmrs/esm-framework';
 import { isEmpty } from '../validators/form-validator';
 import { obsList } from '__mocks__/forms';
 import { type FormField } from '../types';
@@ -135,6 +137,50 @@ describe('utils functions', () => {
 
       expect(hasSubmission(field)).toBe(false);
     });
+  });
+});
+
+describe('getDateWithinVisitWindow', () => {
+  const date = new Date('2026-06-11T12:00:00.000Z');
+
+  it('should return the date unchanged when there is no visit', () => {
+    expect(getDateWithinVisitWindow(date, undefined)).toEqual(date);
+  });
+
+  it('should return the date unchanged when it falls within the visit window', () => {
+    const visit = {
+      startDatetime: '2026-06-11T09:00:00.000Z',
+      stopDatetime: '2026-06-11T17:00:00.000Z',
+    } as Visit;
+
+    expect(getDateWithinVisitWindow(date, visit)).toEqual(date);
+  });
+
+  it('should return the date unchanged for an active visit with no stop datetime', () => {
+    const visit = {
+      startDatetime: '2026-06-11T09:00:00.000Z',
+      stopDatetime: null,
+    } as Visit;
+
+    expect(getDateWithinVisitWindow(date, visit)).toEqual(date);
+  });
+
+  it('should return the visit start datetime when the date is after the visit window (retrospective entry)', () => {
+    const visit = {
+      startDatetime: '2026-06-10T09:00:00.000Z',
+      stopDatetime: '2026-06-10T17:00:00.000Z',
+    } as Visit;
+
+    expect(getDateWithinVisitWindow(date, visit)).toEqual(new Date('2026-06-10T09:00:00.000Z'));
+  });
+
+  it('should return the visit start datetime when the date is before the visit window', () => {
+    const visit = {
+      startDatetime: '2026-06-12T09:00:00.000Z',
+      stopDatetime: null,
+    } as Visit;
+
+    expect(getDateWithinVisitWindow(date, visit)).toEqual(new Date('2026-06-12T09:00:00.000Z'));
   });
 });
 

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { type FormSchema, type FormField, type OpenmrsObs, type RenderType } from '../types';
 import { isEmpty } from '../validators/form-validator';
-import { formatDate, type FormatDateOptions } from '@openmrs/esm-framework';
+import { formatDate, type FormatDateOptions, type Visit } from '@openmrs/esm-framework';
 
 export function flattenObsList(obsList: OpenmrsObs[]): OpenmrsObs[] {
   const flattenedList: OpenmrsObs[] = [];
@@ -73,6 +73,24 @@ export function parseToLocalDateTime(dateString: string): Date {
     console.error(e);
   }
   return dateObj;
+}
+
+/**
+ * Returns `date` if it falls within the visit's start/stop window, otherwise the
+ * visit's start datetime. This keeps default encounter datetimes valid when filling
+ * forms against a past (stopped) visit via retrospective data entry; the backend
+ * rejects encounters dated outside the visit window.
+ */
+export function getDateWithinVisitWindow(date: Date, visit?: Visit): Date {
+  if (!visit) {
+    return date;
+  }
+  const visitStart = visit.startDatetime ? new Date(visit.startDatetime) : null;
+  const visitStop = visit.stopDatetime ? new Date(visit.stopDatetime) : null;
+  if ((visitStart && date < visitStart) || (visitStop && date > visitStop)) {
+    return visitStart ?? visitStop;
+  }
+  return date;
 }
 
 export function formatDateAsDisplayString(field: FormField, date: Date) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

When a form is filled against a past (stopped) visit via retrospective data entry, saving fails with "Error saving encounter - The encounter datetime should be between the visit start and stop dates."

Two paths cause this:

- The engine defaults the encounter datetime to the time the form was opened (`sessionDate`) without consulting the visit's date window.
- When the form has no `encounterDatetime` question (which is the case for most forms), the submission omits the datetime entirely, and the REST backend then defaults it to "now". For a closed past visit, "now" falls outside the visit window and `EncounterValidator` rejects the encounter.

This PR fixes both paths:

- Adds a `getDateWithinVisitWindow` helper that returns the given date unchanged when it falls within the visit's start/stop window, and the visit's start datetime otherwise. This matches how the Angular form entry app handles past visits.
- Constrains `sessionDate` to the visit window at the source, recomputing if the visit prop arrives or hydrates after the form mounts.
- Always submits an explicit encounter datetime for new encounters so the backend never applies its "now" default. An explicit `encounterDatetime` field submission still takes precedence, and editing an existing encounter without changing the date preserves its original datetime.

## Screenshots

### Before

Enable RDE feature flag -> navigate to Clinical forms in the siderail → select the 10-Jun Facility Visit → Continue → Mental Health Assessment Form → set Screening Date to 10/06/2026, answer the two PHQ-2 questions → Save → Backend rejects with "Error saving encounter - The encounter datetime should be between the visit start and stop dates" error

https://github.com/user-attachments/assets/d47d3c6c-7b9c-4192-897e-c02e57acad15

### After 

Enable RDE feature flag -> navigate to Clinical forms in the siderail → Continue → Mental Health Assessment Form → set Screening Date to 10/06/2026, answer the two PHQ-2 questions → Save → "Form submitted successfully", and the encounter lands on the visit dated 10-Jun 09:00 AM.

https://github.com/user-attachments/assets/47bcad28-cccb-4d5b-88c2-4bf994e7b8d8

## Related Issue

https://openmrs.atlassian.net/browse/O3-5735

## Other

Consumers that pass only a visit uuid with no start/stop datetimes (for example the `{ uuid: visitUuid }` fallback in patient-chart's `FormRenderer`) cannot be constrained engine-side. They need to supply the full visit object to get this behavior.