### PR TITLE
(fix) Inline obs date and comment not saved when field visibility is toggled

### DIFF
--- a/__mocks__/forms/rfe-forms/index.ts
+++ b/__mocks__/forms/rfe-forms/index.ts
@@ -41,6 +41,7 @@ export { default as unspecifiedForm } from './sample-unspecified-form.json';
 export { default as viralLoadStatusForm } from './viral-load-status-form.json';
 export { default as weightForHeightZscoreTestSchema } from './zscore-weight-height-form.json';
 export { default as expressionVisitObjectTestSchema } from './expression-visit-object-test.json';
+export { default as obsDateAndCommentForm } from './obs-date-and-comment-form.json';
 
 export { obsList } from './obs-list-data';
 export {

--- a/__mocks__/forms/rfe-forms/obs-date-and-comment-form.json
+++ b/__mocks__/forms/rfe-forms/obs-date-and-comment-form.json
@@ -1,0 +1,62 @@
+{
+  "name": "Obs date and comment",
+  "version": "1",
+  "published": true,
+  "retired": false,
+  "encounterType": "3596fafb-6f6f-4396-8c87-6e63a0f1bd71",
+  "processor": "EncounterFormProcessor",
+  "uuid": "0e8f8f1e-1c2b-4a4d-9c2a-7d7b8a9e0f11",
+  "referencedForms": [],
+  "pages": [
+    {
+      "label": "Results",
+      "sections": [
+        {
+          "label": "Select tests to record",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Which tests do you want to record?",
+              "id": "testsToRecord",
+              "type": "obs",
+              "required": false,
+              "questionOptions": {
+                "rendering": "checkbox-searchable",
+                "isSearchable": true,
+                "concept": "1748a953-d12e-4be1-914c-f6b096c6cdef",
+                "answers": [
+                  {
+                    "concept": "21AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Haemoglobin"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "label": "Results",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Haemoglobin",
+              "id": "haemoglobin",
+              "type": "obs",
+              "required": false,
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "21AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "showDate": true,
+                "showComment": true
+              },
+              "hide": {
+                "hideWhenExpression": "!arrayContains(testsToRecord, '21AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "description": "Form for testing inline obs date and comment"
+}

--- a/src/form-engine.test.tsx
+++ b/src/form-engine.test.tsx
@@ -47,6 +47,7 @@ import {
   testEnrolmentForm,
   viralLoadStatusForm,
   expressionVisitObjectTestSchema,
+  obsDateAndCommentForm,
 } from '__mocks__/forms';
 import { type FormSchema, type OpenmrsEncounter, type SessionMode } from './types';
 import { useEncounter } from './hooks/useEncounter';
@@ -1354,6 +1355,65 @@ describe('Form engine component', () => {
 
         expect(dateInput.value).toContain('28/07/2020');
       });
+    });
+  });
+
+  describe('Inline obs date and comment', () => {
+    const haemoglobinConcept = '21AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+    it('saves the obs datetime entered in the inline date field', async () => {
+      const saveEncounterMock = vi.spyOn(api, 'saveEncounter');
+      await act(async () => {
+        renderForm(null, obsDateAndCommentForm);
+      });
+
+      const testSelector = await screen.findByRole('combobox', { name: /which tests do you want to record/i });
+      await user.click(testSelector);
+      await user.click(await screen.findByRole('option', { name: /haemoglobin/i }));
+
+      const haemoglobinInput = await screen.findByRole('spinbutton', { name: /haemoglobin/i });
+      await user.type(haemoglobinInput, '12');
+
+      const dateInput = await screen.findByRole('textbox', { name: /date for haemoglobin/i });
+      await user.click(dateInput);
+      await user.paste('2024-01-15');
+
+      await user.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(saveEncounterMock).toHaveBeenCalledTimes(1);
+      });
+      const [, encounter] = saveEncounterMock.mock.calls[0];
+      const obs = encounter.obs.find((o) => o.concept === haemoglobinConcept);
+      expect(obs).toBeDefined();
+      expect(dayjs(obs.obsDatetime).format('YYYY-MM-DD')).toBe('2024-01-15');
+    });
+
+    it('saves the comment entered in the inline comment field', async () => {
+      const saveEncounterMock = vi.spyOn(api, 'saveEncounter');
+      await act(async () => {
+        renderForm(null, obsDateAndCommentForm);
+      });
+
+      const testSelector = await screen.findByRole('combobox', { name: /which tests do you want to record/i });
+      await user.click(testSelector);
+      await user.click(await screen.findByRole('option', { name: /haemoglobin/i }));
+
+      const haemoglobinInput = await screen.findByRole('spinbutton', { name: /haemoglobin/i });
+      await user.type(haemoglobinInput, '12');
+
+      const commentInput = await screen.findByRole('textbox', { name: /comment for haemoglobin/i });
+      await user.type(commentInput, 'within normal range');
+
+      await user.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(saveEncounterMock).toHaveBeenCalledTimes(1);
+      });
+      const [, encounter] = saveEncounterMock.mock.calls[0];
+      const obs = encounter.obs.find((o) => o.concept === haemoglobinConcept);
+      expect(obs).toBeDefined();
+      expect(obs.comment).toBe('within normal range');
     });
   });
 

--- a/src/hooks/useFormStateHelpers.test.ts
+++ b/src/hooks/useFormStateHelpers.test.ts
@@ -1,0 +1,41 @@
+import { vi, describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { type FormField } from '../types';
+import { useFormStateHelpers } from './useFormStateHelpers';
+
+const createField = (id: string, overrides: Partial<FormField> = {}): FormField =>
+  ({
+    id,
+    label: id,
+    type: 'obs',
+    questionOptions: { rendering: 'number', concept: `concept-${id}` },
+    meta: { submission: null, initialValue: { omrsObject: null, refinedValue: null } },
+    ...overrides,
+  }) as FormField;
+
+describe('useFormStateHelpers', () => {
+  describe('getFormField', () => {
+    it('returns the current field object after the formFields array is replaced with the same length', () => {
+      // getFormField must reflect field updates even when the array length is unchanged.
+      const dispatch = vi.fn();
+      const initialFields = [createField('a'), createField('b')];
+
+      const { result, rerender } = renderHook(({ fields }) => useFormStateHelpers(dispatch, fields), {
+        initialProps: { fields: initialFields },
+      });
+
+      expect(result.current.getFormField('a')).toBe(initialFields[0]);
+
+      // Simulate a submission being set: the reducer replaces the array (via cloneDeep) with
+      // a new array of the same length holding a fresh 'a' object.
+      const updatedA = createField('a', { meta: { submission: { newValue: { value: 250 } } } } as Partial<FormField>);
+      const updatedFields = [updatedA, initialFields[1]];
+
+      rerender({ fields: updatedFields });
+
+      const resolved = result.current.getFormField('a');
+      expect(resolved).toBe(updatedA);
+      expect(resolved.meta.submission?.newValue).toEqual({ value: 250 });
+    });
+  });
+});

--- a/src/hooks/useFormStateHelpers.ts
+++ b/src/hooks/useFormStateHelpers.ts
@@ -31,7 +31,7 @@ export function useFormStateHelpers(dispatch: Dispatch<Action>, formFields: Form
     (fieldId: string) => {
       return formFields.find((field) => field.id === fieldId);
     },
-    [formFields.length],
+    [formFields],
   );
 
   const removeFormField = useCallback((fieldId: string) => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

**The bug:** When an obs question has an inline date (`showDate`) or comment (`showComment`), the date/comment the user entered could be silently dropped from the saved observation. Instead of the entered date, the obs was saved with the encounter date.

This happened whenever the obs field's visibility, disabled state, or value was driven by another field — i.e. any field that has a dependent expression (`hide`, `disabled`, `calculate`, etc.) referencing it. The plain case (a standalone obs with a date) worked; the bug only surfaced once another field re-evaluated the obs field.

**Why it happened:** The inline date and comment adapters use the `getFormField` helper to look up their parent obs field so they can attach the date/comment to that field's pending submission. `getFormField` was memoized on `formFields.length`. Whenever a dependent expression re-evaluates a field, the engine replaces that field with a fresh copy in a new `formFields` array — but the array length stays the same. Because only the length was watched, `getFormField` kept returning a **stale copy** of the obs field. The adapters wrote the date/comment onto that stale copy, which was discarded, while the live copy that actually got saved never received them.

**The fix:** Memoize `getFormField` on `formFields` itself rather than `formFields.length`, so it always returns the current field object.

## Screenshots

N/A 

## Related Issue

<!-- No Jira ticket linked. Happy to attach one if it should be tracked. -->

## Other
