### PR TITLE
(feat) O3-5815: Show ICD-11 codes next to diagnoses

### DIFF
--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -46,6 +46,7 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
   }, [sessionMode, field.readonly, field.inlineRendering, layoutType, workspaceLayout]);
 
   const selectedItem = useMemo(() => items.find((item) => item.uuid == value) || null, [items, value]);
+  const hasCodes = useMemo(() => items.some((item) => item.code), [items]);
 
   const debouncedSearch = debounce((searchTerm: string, dataSource: DataSource<OpenmrsResource>) => {
     setIsSearching(true);
@@ -169,7 +170,7 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
             items={items}
             itemToElement={(item) => (
               <span className={styles.item}>
-                {item?.code && <span className={styles.code}>{item.code}</span>}
+                {hasCodes && <span className={styles.code}>{item?.code}</span>}
                 <span className={styles.label}>{item?.display}</span>
               </span>
             )}

--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -55,7 +55,7 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
       .then((dataItems) => {
         if (dataItems.length) {
           const currentSelectedItem = items.find((item) => item.uuid == value);
-          const newItems = dataItems.map(dataSource.toUuidAndDisplay);
+          const newItems = dataItems.map((item) => dataSource.toUuidAndDisplay(item, config));
           if (currentSelectedItem && !newItems.some((item) => item.uuid == currentSelectedItem.uuid)) {
             newItems.unshift(currentSelectedItem);
           }
@@ -98,7 +98,7 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
         .fetchData(null, { ...config, referencedValue: dataSourceDependentValue })
         .then((dataItems) => {
           if (!ignore) {
-            setItems(dataItems.map(dataSource.toUuidAndDisplay));
+            setItems(dataItems.map((item) => dataSource.toUuidAndDisplay(item, config)));
             setIsLoading(false);
           }
         })
@@ -128,10 +128,10 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
       // For search-based instances, fetch the initial item to resolve its display property
       setIsLoading(true);
       dataSource
-        .fetchSingleItem(value)
+        .fetchSingleItem(value, config)
         .then((item) => {
           if (!ignore) {
-            setItems([dataSource.toUuidAndDisplay(item)]);
+            setItems([dataSource.toUuidAndDisplay(item, config)]);
             setIsLoading(false);
           }
         })
@@ -146,7 +146,7 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
     return () => {
       ignore = true;
     };
-  }, [value, isDirty, dataSource, isSearchable, items]);
+  }, [value, isDirty, dataSource, isSearchable, items, config]);
 
   if (isLoading) {
     return <DropdownSkeleton />;
@@ -155,7 +155,7 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
   return isViewMode(sessionMode) || isTrue(field.readonly) ? (
     <FieldValueView
       label={t(field.label)}
-      value={value ? items.find((item) => item.uuid == value)?.display : value}
+      value={value ? getItemText(items.find((item) => item.uuid == value)) : value}
       conceptName={field.meta?.concept?.display}
       isInline={isInline}
     />
@@ -167,7 +167,13 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
             id={field.id}
             titleText={<FieldLabel field={field} />}
             items={items}
-            itemToString={(item) => item?.display}
+            itemToElement={(item) => (
+              <span className={styles.item}>
+                {item?.code && <span className={styles.code}>{item.code}</span>}
+                <span className={styles.label}>{item?.display}</span>
+              </span>
+            )}
+            itemToString={getItemText}
             selectedItem={selectedItem}
             placeholder={isSearchable ? t('search', 'Search') + '...' : null}
             onChange={({ selectedItem }) => {
@@ -207,3 +213,7 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
 };
 
 export default UiSelectExtended;
+
+export function getItemText(item?: { code?: string; display?: string }): string {
+  return item?.code ? `${item.code} ${item.display}` : item?.display ?? '';
+}

--- a/src/components/inputs/ui-select-extended/ui-select-extended.scss
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.scss
@@ -17,3 +17,27 @@
 .loader {
   padding: 0.25rem 0.5rem;
 }
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.code {
+  flex: none;
+  min-width: 4rem;
+  max-width: 8rem;
+  overflow: hidden;
+  color: inherit;
+  font-family: 'IBM Plex Mono', 'Menlo', 'Consolas', monospace;
+  font-weight: 600;
+  text-overflow: ellipsis;
+}
+
+.label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/components/inputs/ui-select-extended/ui-select-extended.test.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.test.tsx
@@ -10,6 +10,7 @@ import { mockPatient } from '__mocks__/patient.mock';
 import { mockSessionDataResponse } from '__mocks__/session.mock';
 import { uiSelectExtForm } from '__mocks__/forms';
 import FormEngine from '../../../form-engine.component';
+import { getItemText } from './ui-select-extended.component';
 
 const mockUsePatient = vi.mocked(usePatient);
 const mockUseSession = vi.mocked(useSession);
@@ -162,6 +163,11 @@ describe('UiSelectExtended', () => {
     }));
 
     mockUseSession.mockImplementation(() => mockSessionDataResponse.data);
+  });
+
+  it('includes an optional terminology code in the displayed item text', () => {
+    expect(getItemText({ code: '1A00', display: 'Cholera' })).toBe('1A00 Cholera');
+    expect(getItemText({ display: 'Typhoid arthritis' })).toBe('Typhoid arthritis');
   });
 
   // TODO: Re-enable once the Carbon UiSelectExtended combobox renders its options

--- a/src/datasources/concept-data-source.test.ts
+++ b/src/datasources/concept-data-source.test.ts
@@ -5,6 +5,8 @@ import { ConceptDataSource } from './concept-data-source';
 const mockOpenmrsFetch = vi.mocked(openmrsFetch);
 const codedConceptRepresentation =
   'custom:(uuid,display,conceptClass:(uuid,display),mappings:(conceptMapType:(uuid,display),conceptReferenceTerm:(code,conceptSource:(uuid))))';
+const codedSetMemberRepresentation =
+  'custom:(uuid,setMembers:(uuid,display,mappings:(conceptMapType:(uuid,display),conceptReferenceTerm:(code,conceptSource:(uuid)))))';
 const sameAsConceptMapTypeUuid = '35543629-7d8c-11e1-909d-c80aa9edcf4e';
 
 describe('ConceptDataSource', () => {
@@ -135,5 +137,21 @@ describe('ConceptDataSource', () => {
       `${restBaseUrl}/concept/${concept.uuid}?v=${codedConceptRepresentation}`,
     );
     expect(result).toEqual(concept);
+  });
+
+  it('requests mapped members from the configured concept set', async () => {
+    const setMember = { uuid: 'diagnosis-uuid', display: 'Cholera', mappings: [] };
+    mockOpenmrsFetch.mockResolvedValueOnce({ data: { setMembers: [setMember] } } as any);
+
+    const result = await dataSource.fetchData('cholera', {
+      concept: 'diagnosis-concept-set',
+      conceptSourceUuid: 'icd-11-source',
+      useSetMembersByConcept: true,
+    });
+
+    expect(mockOpenmrsFetch).toHaveBeenCalledWith(
+      `${restBaseUrl}/concept/diagnosis-concept-set?v=${codedSetMemberRepresentation}&q=cholera`,
+    );
+    expect(result).toEqual([setMember]);
   });
 });

--- a/src/datasources/concept-data-source.test.ts
+++ b/src/datasources/concept-data-source.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import { ConceptDataSource } from './concept-data-source';
+
+const mockOpenmrsFetch = vi.mocked(openmrsFetch);
+const codedConceptRepresentation =
+  'custom:(uuid,display,conceptClass:(uuid,display),mappings:(conceptMapType:(uuid,display),conceptReferenceTerm:(code,conceptSource:(uuid))))';
+const sameAsConceptMapTypeUuid = '35543629-7d8c-11e1-909d-c80aa9edcf4e';
+
+describe('ConceptDataSource', () => {
+  let dataSource: ConceptDataSource;
+
+  beforeEach(() => {
+    dataSource = new ConceptDataSource();
+  });
+
+  it('preserves search results without a mapping to the configured source', async () => {
+    const sourceUuid = 'icd-11-source';
+    const matchingConcept = {
+      uuid: 'matching-concept',
+      display: 'Cholera',
+      conceptClass: { uuid: 'diagnosis-class' },
+      mappings: [
+        {
+          conceptReferenceTerm: {
+            code: '1A00',
+            conceptSource: { uuid: sourceUuid },
+          },
+        },
+      ],
+    };
+    const otherConcept = {
+      uuid: 'other-concept',
+      display: 'Other diagnosis',
+      conceptClass: { uuid: 'diagnosis-class' },
+      mappings: [
+        {
+          conceptReferenceTerm: {
+            code: 'OTHER',
+            conceptSource: { uuid: 'other-source' },
+          },
+        },
+      ],
+    };
+    mockOpenmrsFetch.mockResolvedValueOnce({ data: { results: [matchingConcept, otherConcept] } } as any);
+
+    const results = await dataSource.fetchData('cholera', {
+      class: ['diagnosis-class'],
+      conceptSourceUuid: sourceUuid,
+    });
+
+    expect(mockOpenmrsFetch).toHaveBeenCalledWith(
+      `${restBaseUrl}/concept?name=&searchType=fuzzy&v=${codedConceptRepresentation}&q=cholera`,
+    );
+    expect(results).toEqual([matchingConcept, otherConcept]);
+  });
+
+  it('prefers the SAME-AS terminology code without changing the persisted UUID or display', () => {
+    const sourceUuid = 'icd-11-source';
+    const concept = {
+      uuid: 'diagnosis-uuid',
+      display: 'Cholera',
+      mappings: [
+        {
+          conceptMapType: {
+            uuid: 'narrower-than-map-type',
+            display: 'NARROWER-THAN',
+          },
+          conceptReferenceTerm: {
+            code: '1A0Z',
+            conceptSource: { uuid: sourceUuid },
+          },
+        },
+        {
+          conceptMapType: {
+            uuid: sameAsConceptMapTypeUuid,
+            display: 'SAME-AS',
+          },
+          conceptReferenceTerm: {
+            code: '1A00',
+            conceptSource: { uuid: sourceUuid },
+          },
+        },
+      ],
+    };
+
+    expect(dataSource.toUuidAndDisplay(concept, { conceptSourceUuid: sourceUuid })).toEqual({
+      ...concept,
+      code: '1A00',
+    });
+  });
+
+  it('falls back to the first mapping from the configured source', () => {
+    const sourceUuid = 'icd-11-source';
+    const concept = {
+      uuid: 'diagnosis-uuid',
+      display: 'Cholera',
+      mappings: [
+        {
+          conceptMapType: {
+            uuid: 'narrower-than-map-type',
+            display: 'NARROWER-THAN',
+          },
+          conceptReferenceTerm: {
+            code: '1A0Z',
+            conceptSource: { uuid: sourceUuid },
+          },
+        },
+      ],
+    };
+
+    expect(dataSource.toUuidAndDisplay(concept, { conceptSourceUuid: sourceUuid })).toEqual({
+      ...concept,
+      code: '1A0Z',
+    });
+  });
+
+  it('omits the code when the concept has no mapping to the configured source', () => {
+    const concept = {
+      uuid: 'diagnosis-uuid',
+      display: 'Typhoid arthritis',
+      mappings: [],
+    };
+
+    expect(dataSource.toUuidAndDisplay(concept, { conceptSourceUuid: 'icd-11-source' })).toEqual(concept);
+  });
+
+  it('requests mappings when resolving a selected value for a configured source', async () => {
+    const concept = { uuid: 'diagnosis-uuid', display: 'Cholera', mappings: [] };
+    mockOpenmrsFetch.mockResolvedValueOnce({ data: concept } as any);
+
+    const result = await dataSource.fetchSingleItem(concept.uuid, { conceptSourceUuid: 'icd-11-source' });
+
+    expect(mockOpenmrsFetch).toHaveBeenCalledWith(
+      `${restBaseUrl}/concept/${concept.uuid}?v=${codedConceptRepresentation}`,
+    );
+    expect(result).toEqual(concept);
+  });
+});

--- a/src/datasources/concept-data-source.ts
+++ b/src/datasources/concept-data-source.ts
@@ -1,10 +1,32 @@
-import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl, type OpenmrsResource } from '@openmrs/esm-framework';
 import { BaseOpenMRSDataSource } from './data-source';
 import { isEmpty } from '../validators/form-validator';
 
+const baseConceptRepresentation = 'custom:(uuid,display,conceptClass:(uuid,display))';
+const codedConceptRepresentation =
+  'custom:(uuid,display,conceptClass:(uuid,display),mappings:(conceptMapType:(uuid,display),conceptReferenceTerm:(code,conceptSource:(uuid))))';
+const sameAsConceptMapTypeUuid = '35543629-7d8c-11e1-909d-c80aa9edcf4e';
+
+interface ConceptMapping {
+  conceptMapType?: {
+    uuid?: string;
+    display?: string;
+  };
+  conceptReferenceTerm?: {
+    code?: string;
+    conceptSource?: {
+      uuid?: string;
+    };
+  };
+}
+
+interface ConceptResource extends OpenmrsResource {
+  mappings?: Array<ConceptMapping>;
+}
+
 export class ConceptDataSource extends BaseOpenMRSDataSource {
   constructor() {
-    super(`${restBaseUrl}/concept?v=custom:(uuid,display,conceptClass:(uuid,display))`);
+    super(`${restBaseUrl}/concept?v=${baseConceptRepresentation}`);
   }
 
   fetchData(searchTerm: string, config?: Record<string, any>): Promise<any[]> {
@@ -12,7 +34,8 @@ export class ConceptDataSource extends BaseOpenMRSDataSource {
       return Promise.resolve([]);
     }
 
-    let searchUrl = `${restBaseUrl}/concept?name=&searchType=fuzzy&v=custom:(uuid,display,conceptClass:(uuid,display))`;
+    const representation = config?.conceptSourceUuid ? codedConceptRepresentation : baseConceptRepresentation;
+    let searchUrl = `${restBaseUrl}/concept?name=&searchType=fuzzy&v=${representation}`;
     if (config?.class) {
       if (typeof config.class == 'string') {
         const urlParts = searchUrl.split('searchType=fuzzy');
@@ -28,7 +51,10 @@ export class ConceptDataSource extends BaseOpenMRSDataSource {
 
     if (config?.concept && config?.useSetMembersByConcept) {
       let urlParts = searchUrl.split('?name=&searchType=fuzzy&v=');
-      searchUrl = `${urlParts[0]}/${config.concept}?v=custom:(uuid,setMembers:(uuid,display))`;
+      const setMemberRepresentation = config?.conceptSourceUuid
+        ? 'custom:(uuid,setMembers:(uuid,display,mappings:(conceptMapType:(uuid,display),conceptReferenceTerm:(code,conceptSource:(uuid)))))'
+        : 'custom:(uuid,setMembers:(uuid,display))';
+      searchUrl = `${urlParts[0]}/${config.concept}?v=${setMemberRepresentation}`;
       return openmrsFetch(searchTerm ? `${searchUrl}&q=${searchTerm}` : searchUrl).then(({ data }) => {
         // return the setMembers from the retrieved concept object
         return data['setMembers'];
@@ -38,5 +64,33 @@ export class ConceptDataSource extends BaseOpenMRSDataSource {
     return openmrsFetch(searchTerm ? `${searchUrl}&q=${searchTerm}` : searchUrl).then(({ data }) => {
       return data.results;
     });
+  }
+
+  fetchSingleItem(uuid: string, config?: Record<string, any>): Promise<ConceptResource | null> {
+    const representation = config?.conceptSourceUuid ? codedConceptRepresentation : baseConceptRepresentation;
+    return openmrsFetch(`${restBaseUrl}/concept/${uuid}?v=${representation}`).then(({ data }) => data);
+  }
+
+  toUuidAndDisplay(data: ConceptResource, config?: Record<string, any>): OpenmrsResource {
+    const item = super.toUuidAndDisplay(data);
+    const code = this.getConceptSourceMapping(data, config?.conceptSourceUuid)?.conceptReferenceTerm?.code;
+    return code ? { ...item, code } : item;
+  }
+
+  private getConceptSourceMapping(concept: ConceptResource, conceptSourceUuid?: string): ConceptMapping | undefined {
+    if (!conceptSourceUuid) {
+      return undefined;
+    }
+
+    const mappingsToSource =
+      concept.mappings?.filter((mapping) => mapping.conceptReferenceTerm?.conceptSource?.uuid === conceptSourceUuid) ??
+      [];
+    return (
+      mappingsToSource.find(
+        (mapping) =>
+          mapping.conceptMapType?.uuid === sameAsConceptMapTypeUuid ||
+          mapping.conceptMapType?.display?.toUpperCase() === 'SAME-AS',
+      ) ?? mappingsToSource[0]
+    );
   }
 }

--- a/src/transformers/default-schema-transformer.test.ts
+++ b/src/transformers/default-schema-transformer.test.ts
@@ -261,6 +261,51 @@ describe('Default form schema transformer', () => {
     });
   });
 
+  it('should preserve diagnosis datasource config for concept-set diagnoses', () => {
+    const form = {
+      pages: [
+        {
+          sections: [
+            {
+              questions: [
+                {
+                  id: 'primaryDiagnosis',
+                  label: 'Primary diagnosis',
+                  type: 'diagnosis',
+                  questionOptions: {
+                    rendering: 'repeating',
+                    datasource: {
+                      name: 'diagnoses',
+                      config: {
+                        conceptSourceUuid: 'icd-11-source',
+                      },
+                    },
+                    diagnosis: {
+                      conceptSet: 'diagnosis-concept-set',
+                      rank: 1,
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const transformedForm = DefaultFormSchemaTransformer.transform(form as any);
+    const transformedQuestion = transformedForm.pages[0].sections[0].questions[0];
+
+    expect(transformedQuestion.questionOptions.datasource).toEqual({
+      name: 'problem_datasource',
+      config: {
+        conceptSourceUuid: 'icd-11-source',
+        concept: 'diagnosis-concept-set',
+        useSetMembersByConcept: true,
+      },
+    });
+  });
+
   it('should handle multiCheckbox rendering', () => {
     // setup
     const form = {

--- a/src/transformers/default-schema-transformer.test.ts
+++ b/src/transformers/default-schema-transformer.test.ts
@@ -1,4 +1,4 @@
-import { type FormSchema , type PreFilledQuestions } from '../types';
+import { type FormSchema, type PreFilledQuestions } from '../types';
 import { vi, describe, it, expect } from 'vitest';
 import { DefaultFormSchemaTransformer } from './default-schema-transformer';
 import { testForm } from '__mocks__/forms';
@@ -215,6 +215,50 @@ describe('Default form schema transformer', () => {
     // verify
     expect(transformedQuestion.questionOptions.rendering).toEqual('checkbox');
     expect(transformedQuestion.questionOptions.isCheckboxSearchable).toEqual(true);
+  });
+
+  it('should preserve diagnosis datasource config when mapping to the problem datasource', () => {
+    const form = {
+      pages: [
+        {
+          sections: [
+            {
+              questions: [
+                {
+                  id: 'primaryDiagnosis',
+                  label: 'Primary diagnosis',
+                  type: 'diagnosis',
+                  questionOptions: {
+                    rendering: 'repeating',
+                    datasource: {
+                      name: 'diagnoses',
+                      config: {
+                        conceptSourceUuid: 'icd-11-source',
+                      },
+                    },
+                    diagnosis: {
+                      conceptClasses: ['diagnosis-class'],
+                      rank: 1,
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const transformedForm = DefaultFormSchemaTransformer.transform(form as any);
+    const transformedQuestion = transformedForm.pages[0].sections[0].questions[0];
+
+    expect(transformedQuestion.questionOptions.datasource).toEqual({
+      name: 'problem_datasource',
+      config: {
+        conceptSourceUuid: 'icd-11-source',
+        class: ['diagnosis-class'],
+      },
+    });
   });
 
   it('should handle multiCheckbox rendering', () => {

--- a/src/transformers/default-schema-transformer.ts
+++ b/src/transformers/default-schema-transformer.ts
@@ -295,10 +295,12 @@ function handleDiagnosis(question: FormField) {
     ('dataSource' in question.questionOptions && question.questionOptions['dataSource'] === 'diagnoses') ||
     question.type === 'diagnosis'
   ) {
+    const datasourceConfig = question.questionOptions.datasource?.config;
     question.questionOptions.datasource = {
       name: 'problem_datasource',
       config: {
-        class: question.questionOptions.diagnosis?.conceptClasses,
+        ...datasourceConfig,
+        class: question.questionOptions.diagnosis?.conceptClasses ?? datasourceConfig?.class,
       },
     };
     if (question.questionOptions.diagnosis?.conceptSet) {
@@ -308,6 +310,7 @@ function handleDiagnosis(question: FormField) {
         datasource: {
           name: 'problem_datasource',
           config: {
+            ...datasourceConfig,
             useSetMembersByConcept: true,
           },
         },

--- a/src/transformers/default-schema-transformer.ts
+++ b/src/transformers/default-schema-transformer.ts
@@ -311,6 +311,7 @@ function handleDiagnosis(question: FormField) {
           name: 'problem_datasource',
           config: {
             ...datasourceConfig,
+            concept: question.questionOptions.diagnosis.conceptSet,
             useSetMembersByConcept: true,
           },
         },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -75,12 +75,12 @@ export interface DataSource<T> {
    * Fetches a single item from the data source based on its UUID.
    * This is used for value binding with previously selected values.
    */
-  fetchSingleItem(uuid: string): Promise<T | null>;
+  fetchSingleItem(uuid: string, config?: Record<string, any>): Promise<T | null>;
 
   /**
    * Maps a data source item to an object with a uuid and display property
    */
-  toUuidAndDisplay(item: T): OpenmrsResource;
+  toUuidAndDisplay(item: T, config?: Record<string, any>): OpenmrsResource;
 }
 
 export interface ControlTemplate {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Diagnosis questions can configure a terminology source through `datasource.config.conceptSourceUuid`, but the React Form Engine's diagnosis transformer replaced the datasource config. As a result, the concept datasource could not determine which mapping supplied the code to display.

This PR:

- Preserves diagnosis datasource configuration when mapping O3 schemas to the built-in problem datasource, including concept-set diagnoses.
- Passes question-specific datasource config through searches and selected-value resolution.
- Requests concept mappings only when a terminology source is configured, prefers `SAME-AS` mappings, and falls back to the first mapping from that source.
- Keeps diagnoses without a mapping selectable and displays them without a code.
- Renders the optional code before the diagnosis name in options, selected values, and read-only views.

The code is display metadata only. Persisted diagnosis values remain concept UUIDs.

## Screenshots

https://github.com/user-attachments/assets/6d281385-8bd9-414e-8110-9e981b30befd

## Related Issue

https://openmrs.atlassian.net/browse/O3-5815

## Other

This is the React Form Engine counterpart to openmrs/openmrs-ngx-formentry#176.
