### PR TITLE
(chore) O3-5866: Add @carbon/react. to peerDependencies in openmrs-esm-form-engine-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@carbon/react": "^1.83.0",
     "classnames": "^2.5.1",
     "lodash-es": "^4.17.21",
     "react-error-boundary": "^4.0.13",
@@ -48,6 +47,7 @@
     "react-webcam": "^7.2.0"
   },
   "peerDependencies": {
+    "@carbon/react": "1.x",
     "@openmrs/esm-framework": "10.x",
     "dayjs": "1.x",
     "i18next": "25.x",
@@ -56,6 +56,7 @@
     "swr": "2.x"
   },
   "devDependencies": {
+    "@carbon/react": "^1.92.1",
     "@openmrs/eslint-config": "^2.1.0",
     "@openmrs/esm-framework": "next",
     "@openmrs/esm-styleguide": "next",

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,7 +356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/react@npm:^1.83.0, @carbon/react@npm:^1.92.1":
+"@carbon/react@npm:^1.92.1":
   version: 1.92.1
   resolution: "@carbon/react@npm:1.92.1"
   dependencies:
@@ -2425,7 +2425,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-form-engine-lib@workspace:."
   dependencies:
-    "@carbon/react": "npm:^1.83.0"
+    "@carbon/react": "npm:^1.92.1"
     "@openmrs/eslint-config": "npm:^2.1.0"
     "@openmrs/esm-framework": "npm:next"
     "@openmrs/esm-styleguide": "npm:next"
@@ -2470,6 +2470,7 @@ __metadata:
     typescript: "npm:^5.0.0"
     vitest: "npm:^4.1.2"
   peerDependencies:
+    "@carbon/react": 1.x
     "@openmrs/esm-framework": 10.x
     dayjs: 1.x
     i18next: 25.x


### PR DESCRIPTION


## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR updates openmrs-esm-form-engine-lib to declare @carbon/react and @carbon/icons-react as peerDependencies, matching the versions provided by the OpenMRS shell. Previously, because these packages were not listed in peerDependencies, the app bundled its own copies of Carbon React and Carbon Icons, resulting in duplicated frontend bundles and unnecessary runtime-loaded chunks. Since Module Federation derives the shared list from peerDependencies, omitting these packages prevented the app from using the shell-provided singleton instances.

By adding both packages to peerDependencies, this change enables Module Federation to share the shell-provided singletons, reducing duplicate bundle size and improving frontend loading efficiency while keeping existing functionality and tests unchanged.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-5866

## Other
<!-- Anything not covered above -->
