### PR TITLE
(test) Add scaffolding for better testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "src",
     "!src/**/*.test.*",
     "!src/utils/test-utils.ts",
+    "!src/test-support",
     "!src/zscore-tests"
   ],
   "license": "MIT",
@@ -20,7 +21,7 @@
     "test": "cross-env TZ=UTC vitest run --passWithNoTests",
     "test:watch": "cross-env TZ=UTC vitest watch",
     "typescript": "tsc",
-    "build": "rimraf dist && concurrently \"swc --copy-files --ignore '**/*.test.*' --ignore '**/setup-tests.*' --ignore '**/test-utils.*' src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "build": "rimraf dist && concurrently \"swc --copy-files --ignore '**/*.test.*' --ignore '**/setup-tests.*' --ignore '**/test-utils.*' --ignore '**/test-support/**' src -d dist\" \"tsc --project tsconfig.build.json\"",
     "coverage": "yarn test --coverage",
     "prepare": "husky install",
     "extract-translations": "i18next 'src/**/*.component.tsx' 'src/**/*.ts' --config './tools/i18next-parser.config.js'"

--- a/src/components/renderer/form/state.test.ts
+++ b/src/components/renderer/form/state.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { formStateReducer, initialState } from './state';
+import { buildField, buildFormSchema } from '../../../test-support';
+
+// Every assertion compares the WHOLE next state, not just the slice the action
+// targets — dropping `...state` from a reducer case must fail these tests.
+describe('formStateReducer', () => {
+  const fieldA = buildField({ id: 'fieldA' });
+  const fieldB = buildField({ id: 'fieldB' });
+
+  const populatedState = {
+    formFields: [fieldA, fieldB],
+    invalidFields: [fieldA],
+    formJson: buildFormSchema(),
+    deletedFields: [fieldB],
+  };
+
+  describe('form field actions', () => {
+    it('SET_FORM_FIELDS replaces the form fields', () => {
+      const next = formStateReducer(populatedState, { type: 'SET_FORM_FIELDS', value: [fieldA] });
+      expect(next).toEqual({ ...populatedState, formFields: [fieldA] });
+    });
+
+    it('ADD_FORM_FIELD appends a field', () => {
+      const fieldC = buildField({ id: 'fieldC' });
+      const next = formStateReducer(populatedState, { type: 'ADD_FORM_FIELD', value: fieldC });
+      expect(next).toEqual({ ...populatedState, formFields: [fieldA, fieldB, fieldC] });
+    });
+
+    it('UPDATE_FORM_FIELD replaces the field with a matching id', () => {
+      const updatedFieldA = buildField({ id: 'fieldA', label: 'Updated label' });
+      const next = formStateReducer(populatedState, { type: 'UPDATE_FORM_FIELD', value: updatedFieldA });
+      expect(next).toEqual({ ...populatedState, formFields: [updatedFieldA, fieldB] });
+      expect(next.formFields[0]).toBe(updatedFieldA);
+    });
+
+    it('UPDATE_FORM_FIELD is a no-op for an unknown id', () => {
+      const next = formStateReducer(populatedState, {
+        type: 'UPDATE_FORM_FIELD',
+        value: buildField({ id: 'unknown' }),
+      });
+      expect(next).toEqual(populatedState);
+    });
+
+    it('REMOVE_FORM_FIELD removes the field with a matching id', () => {
+      const next = formStateReducer(populatedState, { type: 'REMOVE_FORM_FIELD', value: 'fieldA' });
+      expect(next).toEqual({ ...populatedState, formFields: [fieldB] });
+    });
+  });
+
+  describe('invalid field actions', () => {
+    it('SET_INVALID_FIELDS replaces the invalid fields', () => {
+      const next = formStateReducer(populatedState, { type: 'SET_INVALID_FIELDS', value: [fieldB] });
+      expect(next).toEqual({ ...populatedState, invalidFields: [fieldB] });
+    });
+
+    it('ADD_INVALID_FIELD appends an invalid field', () => {
+      const next = formStateReducer(populatedState, { type: 'ADD_INVALID_FIELD', value: fieldB });
+      expect(next).toEqual({ ...populatedState, invalidFields: [fieldA, fieldB] });
+    });
+
+    it('REMOVE_INVALID_FIELD removes the invalid field with a matching id', () => {
+      const next = formStateReducer(populatedState, { type: 'REMOVE_INVALID_FIELD', value: 'fieldA' });
+      expect(next).toEqual({ ...populatedState, invalidFields: [] });
+    });
+
+    it('CLEAR_INVALID_FIELDS empties the invalid fields', () => {
+      const next = formStateReducer(populatedState, { type: 'CLEAR_INVALID_FIELDS' });
+      expect(next).toEqual({ ...populatedState, invalidFields: [] });
+    });
+  });
+
+  describe('other actions', () => {
+    it('SET_FORM_JSON replaces the form json', () => {
+      const formJson = buildFormSchema({ name: 'Replacement Form' });
+      const next = formStateReducer(populatedState, { type: 'SET_FORM_JSON', value: formJson });
+      expect(next).toEqual({ ...populatedState, formJson });
+      expect(next.formJson).toBe(formJson);
+    });
+
+    it('SET_DELETED_FIELDS replaces the deleted fields', () => {
+      const next = formStateReducer(populatedState, { type: 'SET_DELETED_FIELDS', value: [fieldA] });
+      expect(next).toEqual({ ...populatedState, deletedFields: [fieldA] });
+    });
+
+    it('returns the same state for an unknown action', () => {
+      const next = formStateReducer(populatedState, { type: 'NOT_A_REAL_ACTION' } as any);
+      expect(next).toBe(populatedState);
+    });
+
+    it('starts from an empty initial state', () => {
+      expect(initialState).toEqual({ formFields: [], invalidFields: [], formJson: null, deletedFields: [] });
+    });
+  });
+
+  it('never mutates the previous state', () => {
+    const frozen = Object.freeze({
+      formFields: Object.freeze([fieldA]),
+      invalidFields: Object.freeze([fieldA]),
+      formJson: buildFormSchema(),
+      deletedFields: Object.freeze([fieldB]),
+    });
+
+    expect(() => {
+      formStateReducer(frozen as any, { type: 'SET_FORM_FIELDS', value: [fieldB] });
+      formStateReducer(frozen as any, { type: 'ADD_FORM_FIELD', value: fieldB });
+      formStateReducer(frozen as any, { type: 'UPDATE_FORM_FIELD', value: buildField({ id: 'fieldA' }) });
+      formStateReducer(frozen as any, { type: 'REMOVE_FORM_FIELD', value: 'fieldA' });
+      formStateReducer(frozen as any, { type: 'SET_INVALID_FIELDS', value: [fieldB] });
+      formStateReducer(frozen as any, { type: 'ADD_INVALID_FIELD', value: fieldB });
+      formStateReducer(frozen as any, { type: 'REMOVE_INVALID_FIELD', value: 'fieldA' });
+      formStateReducer(frozen as any, { type: 'CLEAR_INVALID_FIELDS' });
+      formStateReducer(frozen as any, { type: 'SET_FORM_JSON', value: buildFormSchema() });
+      formStateReducer(frozen as any, { type: 'SET_DELETED_FIELDS', value: [] });
+    }).not.toThrow();
+
+    expect(frozen.formFields).toEqual([fieldA]);
+    expect(frozen.invalidFields).toEqual([fieldA]);
+    expect(frozen.deletedFields).toEqual([fieldB]);
+  });
+});

--- a/src/components/sidebar/page-observer.ts
+++ b/src/components/sidebar/page-observer.ts
@@ -5,9 +5,9 @@ class PageObserver {
   private scrollablePagesSubject = new BehaviorSubject<Array<FormPage>>([]);
   private pagesWithErrorsSubject = new BehaviorSubject<Set<string>>(new Set());
   private activePagesSubject = new BehaviorSubject<Set<string>>(new Set());
-  private evaluatedPagesVisibilitySubject = new BehaviorSubject<boolean>(null);
+  private evaluatedPagesVisibilitySubject = new BehaviorSubject<boolean | null>(null);
 
-  setEvaluatedPagesVisibility(evaluatedPagesVisibility: boolean) {
+  setEvaluatedPagesVisibility(evaluatedPagesVisibility: boolean | null) {
     this.evaluatedPagesVisibilitySubject.next(evaluatedPagesVisibility);
   }
 

--- a/src/provider/form-provider.tsx
+++ b/src/provider/form-provider.tsx
@@ -7,6 +7,7 @@ export interface FormContextProps extends FormProcessorContextProps {
   methods: UseFormReturn<any>;
   workspaceLayout: 'minimized' | 'maximized';
   isSubmitting?: boolean;
+  invalidFields?: FormField[];
   deletedFields: FormField[];
   getFormField?: (field: string) => FormField;
   addFormField?: (field: FormField) => void;

--- a/src/registry/registry-cache.ts
+++ b/src/registry/registry-cache.ts
@@ -1,0 +1,43 @@
+import { type ComponentType } from 'react';
+import {
+  type DataSource,
+  type FormFieldInputProps,
+  type FormFieldValidator,
+  type FormFieldValueAdapter,
+  type FormSchemaTransformer,
+  type PostSubmissionAction,
+} from '../types';
+
+interface FormRegistryCache {
+  validators: Record<string, FormFieldValidator>;
+  controls: Record<string, ComponentType<FormFieldInputProps>>;
+  fieldValueAdapters: Record<string, FormFieldValueAdapter>;
+  postSubmissionActions: Record<string, PostSubmissionAction>;
+  dataSources: Record<string, DataSource<any>>;
+  formSchemaTransformers: Record<string, FormSchemaTransformer>;
+}
+
+// Module-level cache of resolved registry items. Lives in its own module (rather
+// than registry.ts) so that test utilities can clear it without importing the full
+// registry module graph, and without expanding the public API surface (src/index.ts
+// re-exports everything from registry.ts).
+export const registryCache: FormRegistryCache = {
+  validators: {},
+  controls: {},
+  fieldValueAdapters: {},
+  postSubmissionActions: {},
+  dataSources: {},
+  formSchemaTransformers: {},
+};
+
+/**
+ * Empties every section of the registry cache in place. Intended for test isolation;
+ * production code never invalidates the cache.
+ */
+export function clearRegistryCache() {
+  Object.values(registryCache).forEach((section: Record<string, unknown>) => {
+    Object.keys(section).forEach((key) => {
+      delete section[key];
+    });
+  });
+}

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -17,6 +17,7 @@ import { inbuiltPostSubmissionActions } from './inbuilt-components/InbuiltPostSu
 import { inbuiltFormTransformers } from './inbuilt-components/inbuiltTransformers';
 import { inbuiltFieldValueAdapters } from './inbuilt-components/inbuiltFieldValueAdapters';
 import { hasRendering } from '../utils/common-utils';
+import { registryCache } from './registry-cache';
 
 /**
  * @internal
@@ -55,24 +56,6 @@ export interface FormsRegistryStoreState {
   expressionHelpers: Record<string, Function>;
   formSchemaTransformers: ComponentRegistration<FormSchemaTransformer>[];
 }
-
-interface FormRegistryCache {
-  validators: Record<string, FormFieldValidator>;
-  controls: Record<string, React.ComponentType<FormFieldInputProps>>;
-  fieldValueAdapters: Record<string, FormFieldValueAdapter>;
-  postSubmissionActions: Record<string, PostSubmissionAction>;
-  dataSources: Record<string, DataSource<any>>;
-  formSchemaTransformers: Record<string, FormSchemaTransformer>;
-}
-
-const registryCache: FormRegistryCache = {
-  validators: {},
-  controls: {},
-  fieldValueAdapters: {},
-  postSubmissionActions: {},
-  dataSources: {},
-  formSchemaTransformers: {},
-};
 
 // Registers
 

--- a/src/test-support/builders.ts
+++ b/src/test-support/builders.ts
@@ -1,0 +1,136 @@
+import { type FormField, type FormPage, type FormSchema } from '../types';
+
+/**
+ * Builders for test fixtures approximating the shape components, adapters, and
+ * validators consume at runtime — i.e. schemas/fields that have already been
+ * through loading and normalization: initialized `meta`, page ids, default
+ * validators on non-group fields. They are an approximation, not a bit-for-bit
+ * reproduction of the pipeline's output (which also stamps things like inherited
+ * `readonly`/`inlineRendering` and evaluated visibility flags).
+ *
+ * Do NOT use these builders for characterization tests of the transform pipeline
+ * itself — those must start from raw JSON fixtures so the transform is what's
+ * being pinned.
+ */
+
+/** Mirrors the page-id derivation in DefaultFormSchemaTransformer.transform. */
+export function derivePageId(label: string, index: number): string {
+  return `page-${(label ?? '').replace(/\s/g, '')}-${index}`;
+}
+
+type FieldOverrides = Partial<FormField> & { id: string };
+
+export function buildField(overrides: FieldOverrides): FormField {
+  const { id, questionOptions, meta, ...rest } = overrides;
+  return {
+    id,
+    label: id,
+    type: 'obs',
+    isHidden: false,
+    isDisabled: false,
+    isParentHidden: false,
+    validators: [{ type: 'form_field' }, { type: 'default_value' }],
+    ...rest,
+    questionOptions: {
+      rendering: 'text',
+      concept: `${id}-concept-uuid`,
+      ...questionOptions,
+    },
+    meta: {
+      submission: null,
+      initialValue: {
+        omrsObject: null,
+        refinedValue: null,
+      },
+      ...meta,
+    },
+  };
+}
+
+type ObsGroupOverrides = Omit<Partial<FormField>, 'id' | 'questions' | 'type'>;
+
+/**
+ * Builds an obsGroup field whose `questions` are copies of `children` stamped with
+ * `meta.groupId` (the input field objects are not mutated — read children back via
+ * `group.questions`). Group-rendered fields get NO default validators, matching
+ * `setFieldValidators`, which skips groups.
+ */
+export function buildObsGroup(id: string, children: FormField[], overrides: ObsGroupOverrides = {}): FormField {
+  return buildField({
+    id,
+    type: 'obsGroup',
+    validators: [],
+    questions: children.map((child) => ({
+      ...child,
+      meta: { ...(child.meta ?? {}), groupId: id },
+    })),
+    ...overrides,
+    questionOptions: {
+      rendering: 'group',
+      ...overrides.questionOptions,
+    },
+  });
+}
+
+interface FormSchemaOptions {
+  name?: string;
+  uuid?: string;
+  encounterType?: string;
+  questions?: FormField[];
+  pages?: FormPage[];
+}
+
+/**
+ * Builds a schema wrapping `questions` in a single page/section. The wrapped
+ * questions get `meta.pageId` stamped with the derived page id, mirroring the
+ * transformer. This intentionally mutates the passed field objects: the schema's
+ * questions and the test's field references must be the SAME objects, because
+ * several engine code paths match fields by identity. When `pages` are supplied
+ * instead, they are used as-is.
+ */
+export function buildFormSchema(options: FormSchemaOptions = {}): FormSchema {
+  const {
+    name = 'Test Form',
+    uuid = 'test-form-uuid',
+    encounterType = 'test-encounter-type-uuid',
+    questions = [],
+    pages,
+  } = options;
+  const defaultPageLabel = 'Page 1';
+  const defaultPageId = derivePageId(defaultPageLabel, 0);
+  if (!pages) {
+    questions.forEach((question) => {
+      question.meta = { ...(question.meta ?? {}), pageId: defaultPageId };
+    });
+  }
+  return {
+    name,
+    uuid,
+    encounterType,
+    processor: 'EncounterFormProcessor',
+    referencedForms: [],
+    pages: pages ?? [
+      {
+        label: defaultPageLabel,
+        id: defaultPageId,
+        sections: [
+          {
+            label: 'Section 1',
+            isExpanded: 'true',
+            questions,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/**
+ * Returns a deep copy of a fixture. Fixtures imported from `__mocks__/forms` are
+ * module-cached singletons, and both the schema transformers and several hooks
+ * mutate schemas in place — tests that share an un-cloned fixture become
+ * order-dependent. Always pass imported fixtures through this before use.
+ */
+export function loadFormFixture<T>(fixture: T): T {
+  return structuredClone(fixture);
+}

--- a/src/test-support/builders.ts
+++ b/src/test-support/builders.ts
@@ -99,9 +99,11 @@ export function buildFormSchema(options: FormSchemaOptions = {}): FormSchema {
   const defaultPageLabel = 'Page 1';
   const defaultPageId = derivePageId(defaultPageLabel, 0);
   if (!pages) {
-    questions.forEach((question) => {
+    const stamp = (question: FormField) => {
       question.meta = { ...(question.meta ?? {}), pageId: defaultPageId };
-    });
+      question.questions?.forEach(stamp);
+    };
+    questions.forEach(stamp);
   }
   return {
     name,

--- a/src/test-support/form-context.tsx
+++ b/src/test-support/form-context.tsx
@@ -1,0 +1,169 @@
+import React, { useMemo, useReducer } from 'react';
+import { render, type RenderResult } from '@testing-library/react';
+import { useForm, type UseFormReturn } from 'react-hook-form';
+import { vi } from 'vitest';
+import { type Visit } from '@openmrs/esm-framework';
+import { mockPatient, mockVisit } from '__mocks__';
+import { FormProvider, type FormContextProps } from '../provider/form-provider';
+import { type FormField, type FormSchema } from '../types';
+import { EncounterFormProcessor } from '../processors/encounter/encounter-form-processor';
+import { inbuiltFieldValueAdapters } from '../registry/inbuilt-components/inbuiltFieldValueAdapters';
+import { inbuiltValidators } from '../registry/inbuilt-components/inbuiltValidators';
+import { formStateReducer, initialState } from '../components/renderer/form/state';
+import { useFormStateHelpers } from '../hooks/useFormStateHelpers';
+import { buildFormSchema } from './builders';
+
+/**
+ * A minimal, non-React stand-in for react-hook-form's `UseFormReturn`. `getValues`
+ * and `setValue` operate on a plain record; `trigger` always passes. Sufficient for
+ * exercising non-component logic that receives `methods` through the form context
+ * (e.g. `validateForm`, submission preparation). Component tests should prefer
+ * `renderWithFormContext`, which uses the real `useForm`.
+ */
+export function createFormMethodsStub(initialValues: Record<string, any> = {}): UseFormReturn<any> {
+  const values: Record<string, any> = { ...initialValues };
+  const stub = {
+    getValues: (nameOrNames?: string | string[]) => {
+      if (nameOrNames === undefined) {
+        return { ...values };
+      }
+      if (Array.isArray(nameOrNames)) {
+        return nameOrNames.map((name) => values[name]);
+      }
+      return values[nameOrNames];
+    },
+    setValue: (name: string, value: any) => {
+      values[name] = value;
+    },
+    watch: (name?: string) => (typeof name === 'string' ? values[name] : { ...values }),
+    trigger: vi.fn(async () => true),
+    getFieldState: vi.fn(() => ({ isDirty: false, isTouched: false, invalid: false, error: undefined })),
+    register: vi.fn(),
+    unregister: vi.fn(),
+    reset: vi.fn(),
+    resetField: vi.fn(),
+    setError: vi.fn(),
+    clearErrors: vi.fn(),
+    setFocus: vi.fn(),
+    handleSubmit: vi.fn(),
+    formState: { isDirty: false, isValid: true, errors: {} },
+    control: {},
+  };
+  return stub as unknown as UseFormReturn<any>;
+}
+
+/**
+ * Builds a complete `FormContextProps` with sensible defaults, using the REAL
+ * inbuilt adapters, validators, and `EncounterFormProcessor` so that tests exercise
+ * production logic rather than mock echoes. Everything is overridable.
+ *
+ * This is the non-React layer; it does not render anything. For component tests use
+ * `renderWithFormContext`.
+ */
+export function createTestFormContext(overrides: Partial<FormContextProps> = {}): FormContextProps {
+  const formJson = overrides.formJson ?? buildFormSchema();
+  const defaults = {
+    patient: mockPatient as fhir.Patient,
+    formJson,
+    visit: mockVisit as unknown as Visit,
+    sessionMode: 'enter' as const,
+    sessionDate: new Date('2026-01-01T10:00:00.000Z'),
+    location: mockVisit.location,
+    currentProvider: { uuid: 'current-provider-uuid', display: 'Current Provider' },
+    layoutType: 'small-desktop' as const,
+    workspaceLayout: 'minimized' as const,
+    processor: new EncounterFormProcessor(formJson),
+    formFields: [] as FormField[],
+    invalidFields: [] as FormField[],
+    deletedFields: [] as FormField[],
+    formFieldAdapters: Object.fromEntries(inbuiltFieldValueAdapters.map((entry) => [entry.type, entry.component])),
+    formFieldValidators: Object.fromEntries(inbuiltValidators.map((entry) => [entry.name, entry.component])),
+    customDependencies: {
+      defaultEncounterRole: { uuid: 'clinician-role-uuid', display: 'Clinician' },
+      patientPrograms: [],
+    },
+    methods: createFormMethodsStub(),
+    getFormField: vi.fn(),
+    addFormField: vi.fn(),
+    updateFormField: vi.fn(),
+    removeFormField: vi.fn(),
+    addInvalidField: vi.fn(),
+    removeInvalidField: vi.fn(),
+    setInvalidFields: vi.fn(),
+    setForm: vi.fn(),
+    setDeletedFields: vi.fn(),
+  };
+  return { ...defaults, ...overrides } as FormContextProps;
+}
+
+export interface RenderWithFormContextOptions {
+  /** Seeds the form-state reducer's `formFields`. Fields should be built with `buildField`. */
+  fields?: FormField[];
+  /** Defaults to a one-page/one-section schema wrapping `fields`. */
+  formJson?: FormSchema;
+  /** react-hook-form `defaultValues`. */
+  initialValues?: Record<string, any>;
+  /** Merged last over the assembled context. */
+  context?: Partial<FormContextProps>;
+}
+
+export type RenderWithFormContextResult = RenderResult & {
+  /** Latest context snapshot, re-captured on every render of the harness. */
+  getContext: () => FormContextProps;
+};
+
+/**
+ * Renders `ui` inside a real `FormProvider` wired the same way `FormRenderer` wires
+ * it: real `useForm`, real `formStateReducer`, real `useFormStateHelpers` — minus
+ * expression evaluation, page observation, and form registration. Replaces the
+ * mock-the-whole-provider pattern in component tests.
+ *
+ * Limitation: there is no `FormFactoryProvider` in the tree, so components that
+ * call `useFormFactory()` (e.g. the repeat control) will throw. Wrap or extend the
+ * harness when testing those.
+ */
+export function renderWithFormContext(
+  ui: React.ReactElement,
+  options: RenderWithFormContextOptions = {},
+): RenderWithFormContextResult {
+  const contextRef: { current: FormContextProps | null } = { current: null };
+  const resolvedFormJson = options.formJson ?? buildFormSchema({ questions: options.fields ?? [] });
+
+  const Harness = ({ children }: { children: React.ReactNode }) => {
+    const methods = useForm({
+      defaultValues: options.initialValues ?? {},
+      mode: 'onChange',
+      reValidateMode: 'onChange',
+      criteriaMode: 'all',
+    });
+    const [{ formFields, invalidFields, formJson, deletedFields }, dispatch] = useReducer(formStateReducer, {
+      ...initialState,
+      formFields: options.fields ?? [],
+      formJson: resolvedFormJson,
+    });
+    const helpers = useFormStateHelpers(dispatch, formFields);
+    const base = useMemo(() => createTestFormContext({ formJson: resolvedFormJson }), []);
+    const context = {
+      ...base,
+      methods,
+      formFields,
+      formJson,
+      invalidFields,
+      deletedFields,
+      ...helpers,
+      ...options.context,
+    } as FormContextProps;
+    contextRef.current = context;
+    return <FormProvider {...context}>{children}</FormProvider>;
+  };
+
+  const result = render(ui, { wrapper: Harness });
+  return Object.assign(result, {
+    getContext: () => {
+      if (!contextRef.current) {
+        throw new Error('renderWithFormContext: context has not been rendered yet');
+      }
+      return contextRef.current;
+    },
+  });
+}

--- a/src/test-support/index.ts
+++ b/src/test-support/index.ts
@@ -1,0 +1,16 @@
+export { buildField, buildObsGroup, buildFormSchema, derivePageId, loadFormFixture } from './builders';
+export {
+  createFormMethodsStub,
+  createTestFormContext,
+  renderWithFormContext,
+  type RenderWithFormContextOptions,
+  type RenderWithFormContextResult,
+} from './form-context';
+export {
+  mockOpenmrsFetchRoutes,
+  formAndClobRoutes,
+  drainUnmatchedFetches,
+  flushOpenmrsFetchRouter,
+  type FetchRoute,
+} from './openmrs-fetch-router';
+export { resetFormEngineModuleState } from './reset';

--- a/src/test-support/openmrs-fetch-router.ts
+++ b/src/test-support/openmrs-fetch-router.ts
@@ -1,0 +1,87 @@
+import { openmrsFetch, type FetchResponse } from '@openmrs/esm-framework';
+import { type Mock } from 'vitest';
+
+export interface FetchRoute {
+  /** URL matcher: a RegExp tested against the URL, or a predicate. */
+  match: RegExp | ((url: string) => boolean);
+  /** HTTP method; matches any method when omitted. */
+  method?: string;
+  /** Static response body, resolved as `{ data: response }`. */
+  response?: unknown;
+  /** Computed response body; takes precedence over `response` when both are set. */
+  respond?: (url: string, init?: RequestInit) => unknown;
+}
+
+let routerInstalled = false;
+const unmatchedRequests: string[] = [];
+
+/**
+ * Installs a URL-routing implementation on the framework mock's `openmrsFetch`.
+ * Centralizes the per-test `when(openmrsFetch).calledWith(...)` pattern.
+ *
+ * An UNMATCHED request rejects with an error naming the URL — but that rejection
+ * alone is not a reliable failure signal (SWR consumers swallow errors, and mocked
+ * async rejections can go unreported). Every miss is therefore also recorded, and
+ * the global `afterEach` in tools/setup-tests.ts fails the test if any were seen
+ * (via `flushOpenmrsFetchRouter`). Tests that intentionally trigger a miss should
+ * call `drainUnmatchedFetches()` after asserting on it.
+ */
+export function mockOpenmrsFetchRoutes(routes: FetchRoute[]): Mock {
+  const fetchMock = openmrsFetch as unknown as Mock;
+  routerInstalled = true;
+  fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const route = routes.find((candidate) => {
+      if (candidate.method && candidate.method.toUpperCase() !== method) {
+        return false;
+      }
+      return candidate.match instanceof RegExp ? candidate.match.test(url) : candidate.match(url);
+    });
+    if (!route) {
+      unmatchedRequests.push(`${method} ${url}`);
+      throw new Error(`mockOpenmrsFetchRoutes: no route matched ${method} ${url}`);
+    }
+    const data = route.respond ? await route.respond(url, init) : route.response;
+    return { data, ok: true, status: 200 } as unknown as FetchResponse;
+  });
+  return fetchMock;
+}
+
+/** Returns the unmatched requests recorded so far and clears the record. */
+export function drainUnmatchedFetches(): string[] {
+  return unmatchedRequests.splice(0, unmatchedRequests.length);
+}
+
+/**
+ * Called from the global `afterEach`. Uninstalls the router if one was installed
+ * (mockReset restores the implementation the framework mock's `openmrsFetch` was
+ * created with — a plain mockClear would leave the routes leaking into later tests
+ * in the same file) and throws if any request went unmatched during the test.
+ */
+export function flushOpenmrsFetchRouter() {
+  if (routerInstalled) {
+    (openmrsFetch as unknown as Mock).mockReset();
+    routerInstalled = false;
+  }
+  const misses = drainUnmatchedFetches();
+  if (misses.length) {
+    throw new Error(
+      `mockOpenmrsFetchRoutes: ${misses.length} request(s) went unmatched during this test:\n  ${misses.join('\n  ')}`,
+    );
+  }
+}
+
+/**
+ * The ubiquitous pair for schema-loading tests: `fetchOpenMRSForm` (GET /form/{uuid}
+ * or GET /form?q=name) and `fetchClobData` (GET /clobdata/{ref}).
+ *
+ * For name-based lookups, pass `{ results: [{ ...form, retired: false }] }` as
+ * `openmrsForm` — the lookup filters on a STRICT `retired === false`, so a fixture
+ * without the `retired` key is treated as not found.
+ */
+export function formAndClobRoutes(openmrsForm: unknown, clobData: unknown): FetchRoute[] {
+  return [
+    { match: (url) => url.includes('/form/') || url.includes('/form?'), response: openmrsForm },
+    { match: (url) => url.includes('/clobdata/'), response: clobData },
+  ];
+}

--- a/src/test-support/openmrs-fetch-router.ts
+++ b/src/test-support/openmrs-fetch-router.ts
@@ -35,7 +35,11 @@ export function mockOpenmrsFetchRoutes(routes: FetchRoute[]): Mock {
       if (candidate.method && candidate.method.toUpperCase() !== method) {
         return false;
       }
-      return candidate.match instanceof RegExp ? candidate.match.test(url) : candidate.match(url);
+      if (candidate.match instanceof RegExp) {
+        candidate.match.lastIndex = 0;
+        return candidate.match.test(url);
+      }
+      return candidate.match(url);
     });
     if (!route) {
       unmatchedRequests.push(`${method} ${url}`);

--- a/src/test-support/reset.ts
+++ b/src/test-support/reset.ts
@@ -1,0 +1,88 @@
+import { getGlobalStore } from '@openmrs/esm-framework';
+import { ObsAdapter } from '../adapters/obs-adapter';
+import { OrdersAdapter } from '../adapters/orders-adapter';
+import { EncounterDiagnosisAdapter } from '../adapters/encounter-diagnosis-adapter';
+import { astCache } from '../utils/ast-cache';
+import { pageObserver } from '../components/sidebar/page-observer';
+import { clearRegistryCache } from '../registry/registry-cache';
+import { type FormsRegistryStoreState } from '../registry/registry';
+import { FormsStore } from '../constants';
+import { teardown as lifecycleTeardown } from '../lifecycle';
+
+// Must return a FRESH object every call: the registry's register* functions mutate
+// the store's containers in place, so a shared template object installed into the
+// store would itself get polluted by the next registration.
+function emptyFormsRegistryState(): FormsRegistryStoreState {
+  return {
+    controls: [],
+    postSubmissionActions: [],
+    expressionHelpers: {},
+    fieldValidators: [],
+    fieldValueAdapters: [],
+    dataSources: [],
+    formSchemaTransformers: [],
+  };
+}
+
+/**
+ * Resets the engine's module-level mutable state between tests (wired as a global
+ * `afterEach` in tools/setup-tests.ts). Because vitest isolates test files, this
+ * matters for leakage between tests WITHIN a file.
+ *
+ * Each entry here is also a refactoring target: when a piece of state is moved
+ * into per-form context, delete its line.
+ *
+ * Known state NOT reset here: `baseRegistry` in src/utils/forms-loader.ts (the
+ * legacy in-memory forms registry). It is module-private with no clear mechanism,
+ * and no test currently writes to it.
+ */
+export function resetFormEngineModuleState() {
+  const steps: Array<[string, () => void]> = [
+    // Adapter "assigned ID" ledgers: module-level arrays tracking which obs/orders/
+    // diagnoses have been bound to fields during hydration. Called directly because
+    // lifecycle teardown only reaches adapters a mounted form registered.
+    ['ObsAdapter.tearDown', () => ObsAdapter.tearDown()],
+    ['OrdersAdapter.tearDown', () => OrdersAdapter.tearDown()],
+    ['EncounterDiagnosisAdapter.tearDown', () => EncounterDiagnosisAdapter.tearDown()],
+    // Adapters registered by mounted forms (src/lifecycle.ts keeps a module-level
+    // Set), plus pageObserver.clear().
+    ['lifecycle.teardown', () => lifecycleTeardown()],
+    // pageObserver.clear() sets evaluatedPagesVisibility to false, but its initial
+    // BehaviorSubject value is null ("not yet evaluated") — restore that.
+    ['pageObserver.evaluatedPagesVisibility', () => pageObserver.setEvaluatedPagesVisibility(null)],
+    // Compiled-expression AST cache (keyed by a 32-bit hash of the expression).
+    ['astCache.clear', () => astCache.clear()],
+    // Resolved registry items (controls, adapters, validators, ...).
+    ['clearRegistryCache', () => clearRegistryCache()],
+    // The registration arrays in the 'forms-engine-store' global store. Without
+    // this, a registerControl/registerExpressionHelper call in one test is visible
+    // to the next — and since the derived cache above IS cleared each test, a
+    // leaked registration would take effect instead of being masked by the cache.
+    [
+      'forms-engine-store',
+      () => {
+        getGlobalStore<FormsRegistryStoreState>(FormsStore, emptyFormsRegistryState()).setState(
+          emptyFormsRegistryState(),
+        );
+      },
+    ],
+  ];
+
+  // Run every step even if one throws, so a single failure can't leave the rest of
+  // the state leaked into subsequent tests.
+  const failures: Array<{ step: string; error: unknown }> = [];
+  for (const [name, step] of steps) {
+    try {
+      step();
+    } catch (error) {
+      failures.push({ step: name, error });
+    }
+  }
+  if (failures.length) {
+    throw new Error(
+      `resetFormEngineModuleState: ${failures.length} step(s) failed: ${failures
+        .map(({ step, error }) => `${step} (${error})`)
+        .join(', ')}`,
+    );
+  }
+}

--- a/src/test-support/test-support.test.tsx
+++ b/src/test-support/test-support.test.tsx
@@ -1,0 +1,190 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import { openmrsFetch } from '@openmrs/esm-framework';
+import { useFormProviderContext } from '../provider/form-provider';
+import { EncounterFormProcessor } from '../processors/encounter/encounter-form-processor';
+import { ObsAdapter, assignedObsIds } from '../adapters/obs-adapter';
+import { astCache } from '../utils/ast-cache';
+import { registryCache } from '../registry/registry-cache';
+import { getRegisteredExpressionHelpers, registerExpressionHelper } from '../registry/registry';
+import { buildField, buildFormSchema, buildObsGroup, loadFormFixture } from './builders';
+import { createFormMethodsStub, createTestFormContext, renderWithFormContext } from './form-context';
+import { drainUnmatchedFetches, mockOpenmrsFetchRoutes } from './openmrs-fetch-router';
+import { resetFormEngineModuleState } from './reset';
+
+describe('builders', () => {
+  it('buildField produces the post-pipeline shape with overridable defaults', () => {
+    const field = buildField({ id: 'weight', questionOptions: { rendering: 'number' } });
+
+    expect(field.type).toBe('obs');
+    expect(field.label).toBe('weight');
+    expect(field.questionOptions.rendering).toBe('number');
+    expect(field.questionOptions.concept).toBe('weight-concept-uuid');
+    expect(field.meta.submission).toBeNull();
+    expect(field.meta.initialValue).toEqual({ omrsObject: null, refinedValue: null });
+    expect(field.validators).toEqual([{ type: 'form_field' }, { type: 'default_value' }]);
+  });
+
+  it('buildObsGroup stamps copies of the children with the group id, without default validators', () => {
+    const child = buildField({ id: 'child' });
+    const group = buildObsGroup('group1', [child]);
+
+    expect(group.type).toBe('obsGroup');
+    expect(group.questionOptions.rendering).toBe('group');
+    expect(group.validators).toEqual([]);
+    expect(group.questions[0].meta.groupId).toBe('group1');
+    // The caller's field object is not mutated; group.questions holds the copies.
+    expect(child.meta.groupId).toBeUndefined();
+  });
+
+  it('buildFormSchema wraps questions in a single page/section with the derived page id', () => {
+    const field = buildField({ id: 'a' });
+    const schema = buildFormSchema({ questions: [field] });
+
+    expect(schema.pages).toHaveLength(1);
+    // Matches DefaultFormSchemaTransformer's derivation: whitespace stripped from the label.
+    expect(schema.pages[0].id).toBe('page-Page1-0');
+    expect(field.meta.pageId).toBe('page-Page1-0');
+    expect(schema.pages[0].sections[0].questions[0]).toBe(field);
+  });
+
+  it('loadFormFixture returns a deep copy', () => {
+    const fixture = { nested: { value: 1 } };
+    const copy = loadFormFixture(fixture);
+
+    expect(copy).toEqual(fixture);
+    expect(copy).not.toBe(fixture);
+    expect(copy.nested).not.toBe(fixture.nested);
+  });
+});
+
+describe('createFormMethodsStub', () => {
+  it('backs getValues/setValue/watch with a live record', async () => {
+    const methods = createFormMethodsStub({ a: 1 });
+
+    expect(methods.getValues('a')).toBe(1);
+    methods.setValue('b', 2);
+    expect(methods.getValues(['a', 'b'])).toEqual([1, 2]);
+    expect(methods.getValues()).toEqual({ a: 1, b: 2 });
+    expect(methods.watch('b')).toBe(2);
+    await expect(methods.trigger()).resolves.toBe(true);
+  });
+});
+
+describe('createTestFormContext', () => {
+  it('wires real inbuilt adapters, validators, and processor by default', () => {
+    const context = createTestFormContext();
+
+    expect(context.formFieldAdapters.obs).toBe(ObsAdapter);
+    expect(context.formFieldValidators.form_field).toBeDefined();
+    expect(context.processor).toBeInstanceOf(EncounterFormProcessor);
+    expect(context.sessionMode).toBe('enter');
+    expect(context.patient.id).toBeDefined();
+  });
+
+  it('applies overrides last', () => {
+    const formJson = buildFormSchema({ name: 'Override Form' });
+    const context = createTestFormContext({ sessionMode: 'edit', formJson });
+
+    expect(context.sessionMode).toBe('edit');
+    expect(context.formJson.name).toBe('Override Form');
+    expect(context.processor.formJson.name).toBe('Override Form');
+  });
+});
+
+describe('renderWithFormContext', () => {
+  const Probe = () => {
+    const { formFields } = useFormProviderContext();
+    return <div data-testid="probe">{formFields.map((field) => field.id).join(',')}</div>;
+  };
+
+  it('provides a real form context seeded with the given fields', () => {
+    renderWithFormContext(<Probe />, { fields: [buildField({ id: 'a' }), buildField({ id: 'b' })] });
+
+    expect(screen.getByTestId('probe')).toHaveTextContent('a,b');
+  });
+
+  it('exposes a live context snapshot whose state helpers drive the real reducer', () => {
+    const result = renderWithFormContext(<Probe />, { fields: [buildField({ id: 'a' })] });
+
+    act(() => {
+      result.getContext().addInvalidField(result.getContext().formFields[0]);
+    });
+    expect(result.getContext().invalidFields.map((field) => field.id)).toEqual(['a']);
+
+    act(() => {
+      result.getContext().removeInvalidField('a');
+    });
+    expect(result.getContext().invalidFields).toEqual([]);
+  });
+
+  it('uses the real react-hook-form instance', async () => {
+    const result = renderWithFormContext(<Probe />, {
+      fields: [buildField({ id: 'a' })],
+      initialValues: { a: 'initial' },
+    });
+
+    expect(result.getContext().methods.getValues('a')).toBe('initial');
+    act(() => {
+      result.getContext().methods.setValue('a', 'changed');
+    });
+    expect(result.getContext().methods.getValues('a')).toBe('changed');
+  });
+});
+
+describe('mockOpenmrsFetchRoutes', () => {
+  it('routes by URL pattern and method, unwrapping to { data }', async () => {
+    mockOpenmrsFetchRoutes([
+      { match: /\/concept\//, response: { uuid: 'concept-uuid' } },
+      { match: (url) => url.includes('/encounter'), method: 'POST', response: { uuid: 'saved' } },
+    ]);
+
+    const conceptResponse = await openmrsFetch('/ws/rest/v1/concept/123');
+    expect(conceptResponse.data).toEqual({ uuid: 'concept-uuid' });
+
+    const saveResponse = await openmrsFetch('/ws/rest/v1/encounter', { method: 'POST' } as any);
+    expect(saveResponse.data).toEqual({ uuid: 'saved' });
+  });
+
+  it('rejects loudly for unmatched requests and records the miss for the global afterEach', async () => {
+    mockOpenmrsFetchRoutes([{ match: /\/concept\//, response: {} }]);
+
+    await expect(openmrsFetch('/ws/rest/v1/somewhere-else')).rejects.toThrow(/no route matched GET .*somewhere-else/);
+    await expect(openmrsFetch('/ws/rest/v1/concept/1', { method: 'POST' } as any)).resolves.toBeDefined();
+
+    // The miss was recorded; drain it so the global afterEach flush (which fails
+    // tests with unmatched fetches) does not fail this intentional one.
+    expect(drainUnmatchedFetches()).toEqual(['GET /ws/rest/v1/somewhere-else']);
+  });
+
+  it('supports respond functions receiving the url', async () => {
+    mockOpenmrsFetchRoutes([{ match: /\/form\//, respond: (url) => ({ requested: url }) }]);
+
+    const response = await openmrsFetch('/ws/rest/v1/form/abc');
+    expect(response.data).toEqual({ requested: '/ws/rest/v1/form/abc' });
+  });
+});
+
+describe('resetFormEngineModuleState', () => {
+  it('clears the adapter ID ledgers, AST cache, and registry cache', () => {
+    assignedObsIds.push('leaked-obs-uuid');
+    astCache.set(42, {} as any);
+    registryCache.controls['text'] = (() => null) as any;
+
+    resetFormEngineModuleState();
+
+    expect(assignedObsIds).toEqual([]);
+    expect(astCache.size).toBe(0);
+    expect(registryCache.controls).toEqual({});
+  });
+
+  it('clears registrations from the forms-engine-store', () => {
+    registerExpressionHelper('leakedHelper', () => 42);
+    expect(getRegisteredExpressionHelpers().leakedHelper).toBeDefined();
+
+    resetFormEngineModuleState();
+
+    expect(getRegisteredExpressionHelpers().leakedHelper).toBeUndefined();
+  });
+});

--- a/src/utils/ast-cache.ts
+++ b/src/utils/ast-cache.ts
@@ -1,0 +1,7 @@
+import { type compile } from '@openmrs/esm-framework';
+
+// Cache of compiled expression ASTs keyed by a hash of the expression source.
+// Lives in its own module (rather than expression-runner.ts) so that test utilities
+// can clear it without importing the expression runner's full module graph
+// (which reaches the registry and, through it, every inbuilt control).
+export const astCache = new Map<number, ReturnType<typeof compile>>();

--- a/src/utils/boolean-utils.test.ts
+++ b/src/utils/boolean-utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { isTrue, isUuid } from './boolean-utils';
+
+describe('isTrue', () => {
+  it('passes booleans through', () => {
+    expect(isTrue(true)).toBe(true);
+    expect(isTrue(false)).toBe(false);
+  });
+
+  it('parses the literal string "true"', () => {
+    expect(isTrue('true')).toBe(true);
+  });
+
+  it('treats every other string as false, including "TRUE" and "1"', () => {
+    expect(isTrue('false')).toBe(false);
+    expect(isTrue('TRUE')).toBe(false);
+    expect(isTrue('1')).toBe(false);
+    expect(isTrue('yes')).toBe(false);
+    expect(isTrue('')).toBe(false);
+  });
+
+  it('coerces non-string, non-boolean values to their truthiness', () => {
+    expect(isTrue(undefined)).toBe(false);
+    expect(isTrue(null)).toBe(false);
+    expect(isTrue(1 as any)).toBe(true);
+    expect(isTrue(0 as any)).toBe(false);
+  });
+});
+
+describe('isUuid', () => {
+  it('accepts canonical UUIDs in either case', () => {
+    expect(isUuid('9e1a2c9c-8bfa-4f52-b1f1-9b7a1a2c9c8b')).toBe(true);
+    expect(isUuid('9E1A2C9C-8BFA-4F52-B1F1-9B7A1A2C9C8B')).toBe(true);
+  });
+
+  it('rejects anything that is not a dashed 8-4-4-4-12 hex string', () => {
+    expect(isUuid('not-a-uuid')).toBe(false);
+    expect(isUuid('9e1a2c9c8bfa4f52b1f19b7a1a2c9c8b')).toBe(false);
+    expect(isUuid('9e1a2c9c-8bfa-4f52-b1f1')).toBe(false);
+    expect(isUuid('')).toBe(false);
+    // The engine treats form NAMES as the non-UUID branch of form lookups; a name
+    // must never satisfy this predicate.
+    expect(isUuid('Adult Return Visit Form')).toBe(false);
+  });
+});

--- a/src/utils/common-utils.test.ts
+++ b/src/utils/common-utils.test.ts
@@ -5,7 +5,10 @@ import {
   gracefullySetSubmission,
   hasRendering,
   hasSubmission,
+  isViewMode,
   parseToLocalDateTime,
+  pxToRem,
+  updateFormSectionReferences,
 } from './common-utils';
 import { vi, describe, it, expect, type Mock } from 'vitest';
 import { type Visit } from '@openmrs/esm-framework';
@@ -181,6 +184,54 @@ describe('getDateWithinVisitWindow', () => {
     } as Visit;
 
     expect(getDateWithinVisitWindow(date, visit)).toEqual(new Date('2026-06-12T09:00:00.000Z'));
+  });
+});
+
+describe('isViewMode', () => {
+  it('returns true for view and embedded-view', () => {
+    expect(isViewMode('view')).toBe(true);
+    expect(isViewMode('embedded-view')).toBe(true);
+  });
+
+  it('returns false for enter and edit', () => {
+    expect(isViewMode('enter')).toBe(false);
+    expect(isViewMode('edit')).toBe(false);
+  });
+});
+
+describe('updateFormSectionReferences', () => {
+  it('returns a new top-level object with new sections arrays but the same page objects', () => {
+    const section = { label: 'Section', isExpanded: 'true', questions: [] };
+    const page = { label: 'Page', sections: [section] };
+    const originalSections = page.sections;
+    const formJson = { name: 'Form', pages: [page] } as any;
+
+    const result = updateFormSectionReferences(formJson);
+
+    expect(result).not.toBe(formJson);
+    expect(result.pages[0]).toBe(page);
+    expect(result.pages[0].sections).not.toBe(originalSections);
+    expect(result.pages[0].sections[0]).toBe(section);
+  });
+
+  it('reassigns the pages array on the input object (mutating it)', () => {
+    const originalPages = [{ label: 'Page', sections: [] }];
+    const formJson = { name: 'Form', pages: originalPages } as any;
+
+    updateFormSectionReferences(formJson);
+
+    expect(formJson.pages).not.toBe(originalPages);
+  });
+});
+
+describe('pxToRem', () => {
+  it('divides by the default 16px font size', () => {
+    expect(pxToRem(32)).toBe(2);
+    expect(pxToRem(8)).toBe(0.5);
+  });
+
+  it('honors a custom font size', () => {
+    expect(pxToRem(32, 8)).toBe(4);
   });
 });
 

--- a/src/utils/error-utils.test.ts
+++ b/src/utils/error-utils.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import { showSnackbar } from '@openmrs/esm-framework';
+import { extractErrorMessagesFromResponse, reportError } from './error-utils';
+
+describe('extractErrorMessagesFromResponse', () => {
+  it('returns the top-level REST error message when there are no field or global errors', () => {
+    const error = { responseBody: { error: { message: 'Invalid submission' } } };
+    expect(extractErrorMessagesFromResponse(error)).toEqual(['Invalid submission']);
+  });
+
+  it('falls back to the plain Error message when there is no response body', () => {
+    expect(extractErrorMessagesFromResponse(new Error('Network failure'))).toEqual(['Network failure']);
+  });
+
+  it('returns [undefined] when no message exists anywhere', () => {
+    expect(extractErrorMessagesFromResponse({})).toEqual([undefined]);
+  });
+
+  it('flattens field error messages across fields', () => {
+    const error = {
+      responseBody: {
+        error: {
+          fieldErrors: {
+            encounterDatetime: [{ message: 'Date cannot be in the future' }, { message: 'Date is required' }],
+            location: [{ message: 'Location is required' }],
+          },
+        },
+      },
+    };
+    expect(extractErrorMessagesFromResponse(error)).toEqual([
+      'Date cannot be in the future',
+      'Date is required',
+      'Location is required',
+    ]);
+  });
+
+  it('prefers global errors over field errors when both are present', () => {
+    const error = {
+      responseBody: {
+        error: {
+          fieldErrors: { location: [{ message: 'Location is required' }] },
+          globalErrors: [{ message: 'Encounter validation failed' }],
+        },
+      },
+    };
+    expect(extractErrorMessagesFromResponse(error)).toEqual(['Encounter validation failed']);
+  });
+
+  it('treats an empty fieldErrors object as no field errors', () => {
+    const error = {
+      responseBody: { error: { fieldErrors: {}, message: 'Fallback message' } },
+    };
+    expect(extractErrorMessagesFromResponse(error)).toEqual(['Fallback message']);
+  });
+
+  it('throws when globalErrors is an empty array and there are no fieldErrors', () => {
+    // Pins a real defect: an empty (truthy) globalErrors array skips the fallback
+    // guard, then the empty-length check routes to Object.values(fieldErrors) with
+    // fieldErrors undefined. Every caller sits inside a catch block, so this throw
+    // replaces the original error. Recorded here so the eventual fix is a
+    // deliberate, visible behavior change.
+    const error = { responseBody: { error: { globalErrors: [] } } };
+    expect(() => extractErrorMessagesFromResponse(error)).toThrow(TypeError);
+  });
+});
+
+describe('reportError', () => {
+  let consoleErrorSpy: MockInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('shows an error snackbar with the extracted message and logs the error', () => {
+    const error = new Error('Something went wrong');
+    reportError(error, 'Error saving encounter');
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+    expect(showSnackbar).toHaveBeenCalledWith({
+      title: 'Error saving encounter',
+      subtitle: 'Something went wrong',
+      kind: 'error',
+      isLowContrast: false,
+    });
+  });
+
+  it('joins multiple extracted messages with a comma', () => {
+    const error = {
+      responseBody: {
+        error: {
+          fieldErrors: {
+            a: [{ message: 'first' }],
+            b: [{ message: 'second' }],
+          },
+        },
+      },
+    } as unknown as Error;
+    reportError(error, 'Error');
+
+    expect(showSnackbar).toHaveBeenCalledWith(expect.objectContaining({ subtitle: 'first, second' }));
+  });
+
+  it('does nothing when the error is null', () => {
+    reportError(null, 'Error saving encounter');
+
+    expect(showSnackbar).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/expression-runner.ts
+++ b/src/utils/expression-runner.ts
@@ -3,6 +3,7 @@ import { isEmpty } from 'lodash-es';
 import { type OpenmrsEncounter, type FormField, type FormPage, type FormSection } from '../types';
 import { CommonExpressionHelpers, registerDependency, simpleHash } from './common-expression-helpers';
 import { HistoricalDataSourceService } from '../datasources/historical-data-source';
+import { astCache } from './ast-cache';
 import {
   compile,
   type DefaultEvaluateReturnType,
@@ -28,7 +29,7 @@ export interface ExpressionContext {
 
 export type EvaluateReturnType = DefaultEvaluateReturnType | Record<string, any>;
 
-export const astCache = new Map();
+export { astCache };
 
 function typePredicate(result: unknown): result is EvaluateReturnType {
   return (

--- a/src/utils/form-helper.test.ts
+++ b/src/utils/form-helper.test.ts
@@ -4,7 +4,13 @@ import {
   evaluateDisabled,
   isPageContentVisible,
   extractObsValueAndDisplay,
+  shouldUseInlineLayout,
+  findPagesWithErrors,
+  findFieldSection,
+  evaluateConditionalAnswered,
+  evalConditionalRequired,
 } from './form-helper';
+import { buildField, buildFormSchema } from '../test-support';
 import { vi, describe, it, expect, test, beforeEach, type Mock } from 'vitest';
 import { ConceptTrue } from '../constants';
 import type { FormPage, FormField } from '../types';
@@ -661,5 +667,151 @@ describe('Form Engine Helper', () => {
         });
       });
     });
+  });
+});
+
+describe('shouldUseInlineLayout', () => {
+  it('always inlines in embedded-view mode', () => {
+    expect(shouldUseInlineLayout('multiline', 'tablet', 'minimized', 'embedded-view')).toBe(true);
+  });
+
+  it('inlines automatic rendering only in a maximized desktop workspace', () => {
+    expect(shouldUseInlineLayout('automatic', 'small-desktop', 'maximized', 'enter')).toBe(true);
+    expect(shouldUseInlineLayout('automatic', 'large-desktop', 'maximized', 'enter')).toBe(true);
+    expect(shouldUseInlineLayout('automatic', 'tablet', 'maximized', 'enter')).toBe(false);
+    expect(shouldUseInlineLayout('automatic', 'small-desktop', 'minimized', 'enter')).toBe(false);
+  });
+
+  it('inlines single-line rendering and never multiline outside embedded-view', () => {
+    expect(shouldUseInlineLayout('single-line', 'tablet', 'minimized', 'enter')).toBe(true);
+    expect(shouldUseInlineLayout('multiline', 'large-desktop', 'maximized', 'enter')).toBe(false);
+  });
+});
+
+describe('findPagesWithErrors', () => {
+  const fieldA = buildField({ id: 'fieldA' });
+  const fieldB = buildField({ id: 'fieldB' });
+  const fieldC = buildField({ id: 'fieldC' });
+  const pageOne = {
+    label: 'Page 1',
+    sections: [{ label: 'Section 1', isExpanded: 'true', questions: [fieldA, fieldB] }],
+  } as any;
+  const pageTwo = {
+    label: 'Page 2',
+    sections: [{ label: 'Section 2', isExpanded: 'true', questions: [fieldC] }],
+  } as any;
+
+  it('returns the labels of pages containing error fields', () => {
+    expect(findPagesWithErrors(new Set([pageOne, pageTwo]), [fieldA, fieldC])).toEqual(['Page 1', 'Page 2']);
+  });
+
+  it('does not duplicate a page when it has multiple error fields', () => {
+    expect(findPagesWithErrors(new Set([pageOne, pageTwo]), [fieldA, fieldB])).toEqual(['Page 1']);
+  });
+
+  it('returns an empty list when there are no error fields', () => {
+    expect(findPagesWithErrors(new Set([pageOne, pageTwo]), [])).toEqual([]);
+  });
+
+  it('matches error fields by object identity, not id', () => {
+    const cloneOfFieldA = buildField({ id: 'fieldA' });
+    expect(findPagesWithErrors(new Set([pageOne]), [cloneOfFieldA])).toEqual([]);
+  });
+});
+
+describe('findFieldSection', () => {
+  it('finds the section containing the field on the page referenced by meta.pageId', () => {
+    const field = buildField({ id: 'question1' });
+    const formJson = buildFormSchema({ questions: [field] });
+
+    expect(findFieldSection(formJson, field).label).toBe('Section 1');
+  });
+
+  it('returns undefined when the page has no section containing the field', () => {
+    const field = buildField({ id: 'question1' });
+    const formJson = buildFormSchema({ questions: [] });
+    field.meta.pageId = formJson.pages[0].id;
+
+    expect(findFieldSection(formJson, field)).toBeUndefined();
+  });
+});
+
+describe('evaluateConditionalAnswered', () => {
+  it('registers the field as a dependent of the referenced field', () => {
+    const referenced = buildField({ id: 'referenced' });
+    const dependent = buildField({
+      id: 'dependent',
+      validators: [{ type: 'conditionalAnswered', referenceQuestionId: 'referenced' }],
+    });
+
+    evaluateConditionalAnswered(dependent, [referenced, dependent]);
+
+    expect(referenced.fieldDependents).toEqual(new Set(['dependent']));
+  });
+
+  it('preserves previously registered dependents', () => {
+    const referenced = buildField({ id: 'referenced', fieldDependents: new Set(['existing']) });
+    const dependent = buildField({
+      id: 'dependent',
+      validators: [{ type: 'conditionalAnswered', referenceQuestionId: 'referenced' }],
+    });
+
+    evaluateConditionalAnswered(dependent, [referenced, dependent]);
+
+    expect(referenced.fieldDependents).toEqual(new Set(['existing', 'dependent']));
+  });
+
+  it('does nothing when the referenced field does not exist', () => {
+    const dependent = buildField({
+      id: 'dependent',
+      validators: [{ type: 'conditionalAnswered', referenceQuestionId: 'missing' }],
+    });
+
+    expect(() => evaluateConditionalAnswered(dependent, [dependent])).not.toThrow();
+  });
+});
+
+describe('evalConditionalRequired', () => {
+  const conditionallyRequired = () =>
+    buildField({
+      id: 'dependent',
+      required: {
+        type: 'conditionalRequired',
+        referenceQuestionId: 'referenced',
+        referenceQuestionAnswers: ['yes-uuid'],
+      },
+    });
+
+  it('returns false when required is not the conditional object form', () => {
+    const field = buildField({ id: 'plain', required: true });
+    expect(evalConditionalRequired(field, [field], {})).toBe(false);
+  });
+
+  it('returns true when the referenced field has one of the trigger answers', () => {
+    const referenced = buildField({ id: 'referenced' });
+    const field = conditionallyRequired();
+
+    expect(evalConditionalRequired(field, [referenced, field], { referenced: 'yes-uuid' })).toBe(true);
+  });
+
+  it('returns false when the referenced field has a different answer', () => {
+    const referenced = buildField({ id: 'referenced' });
+    const field = conditionallyRequired();
+
+    expect(evalConditionalRequired(field, [referenced, field], { referenced: 'no-uuid' })).toBe(false);
+  });
+
+  it('registers the field as a dependent of the referenced field', () => {
+    const referenced = buildField({ id: 'referenced' });
+    const field = conditionallyRequired();
+
+    evalConditionalRequired(field, [referenced, field], {});
+
+    expect(referenced.fieldDependents).toEqual(new Set(['dependent']));
+  });
+
+  it('returns false when the referenced field does not exist', () => {
+    const field = conditionallyRequired();
+    expect(evalConditionalRequired(field, [field], { referenced: 'yes-uuid' })).toBe(false);
   });
 });

--- a/src/utils/post-submission-action-helper.test.ts
+++ b/src/utils/post-submission-action-helper.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { evaluatePostSubmissionExpression } from './post-submission-action-helper';
+
+/**
+ * Characterization tests pinning the semantics of the post-submission `enabled`
+ * expression evaluator, including its quirks: string substitution into `eval`,
+ * `includes`-based obs matching, and `'undefined'` substitution for missing
+ * fields. Any change to the evaluation mechanism must preserve (or deliberately
+ * revisit) each behavior pinned here.
+ */
+describe('evaluatePostSubmissionExpression', () => {
+  const encounterWithObs = (obs: Array<{ fieldId: string; value: unknown }>) => [
+    {
+      obs: obs.map(({ fieldId, value }) => ({ formFieldPath: `rfe-forms-${fieldId}`, value })),
+    },
+  ];
+
+  it('evaluates a literal boolean expression with no field references', () => {
+    expect(evaluatePostSubmissionExpression('true', encounterWithObs([]))).toBe(true);
+    expect(evaluatePostSubmissionExpression('false', encounterWithObs([]))).toBe(false);
+  });
+
+  it('substitutes a coded obs value (object) by its uuid', () => {
+    const encounters = encounterWithObs([{ fieldId: 'tbScreening', value: { uuid: 'positive-concept-uuid' } }]);
+    expect(evaluatePostSubmissionExpression("tbScreening === 'positive-concept-uuid'", encounters)).toBe(true);
+    expect(evaluatePostSubmissionExpression("tbScreening === 'some-other-uuid'", encounters)).toBe(false);
+  });
+
+  it('substitutes a string obs value, quoting it for evaluation', () => {
+    const encounters = encounterWithObs([{ fieldId: 'status', value: 'active' }]);
+    expect(evaluatePostSubmissionExpression("status == 'active'", encounters)).toBe(true);
+    expect(evaluatePostSubmissionExpression("status == 'inactive'", encounters)).toBe(false);
+  });
+
+  it('substitutes numeric obs values unquoted so comparisons work', () => {
+    const encounters = encounterWithObs([{ fieldId: 'weight', value: 75 }]);
+    expect(evaluatePostSubmissionExpression('weight > 50', encounters)).toBe(true);
+    expect(evaluatePostSubmissionExpression('weight > 100', encounters)).toBe(false);
+  });
+
+  it('matches obs by substring of formFieldPath', () => {
+    // The lookup uses formFieldPath.includes(fieldId); an expression naming `visit`
+    // matches an obs whose path is rfe-forms-visitType. This over-matching is
+    // existing behavior — pinned here so a change to exact matching is deliberate.
+    const encounters = encounterWithObs([{ fieldId: 'visitType', value: 'outpatient' }]);
+    expect(evaluatePostSubmissionExpression("visit == 'outpatient'", encounters)).toBe(true);
+  });
+
+  it("substitutes 'undefined' for referenced fields with no matching obs", () => {
+    const encounters = encounterWithObs([{ fieldId: 'weight', value: 75 }]);
+    expect(evaluatePostSubmissionExpression("missingField === 'anything'", encounters)).toBe(false);
+  });
+
+  it('combines multiple field references in one expression', () => {
+    const encounters = encounterWithObs([
+      { fieldId: 'weight', value: 75 },
+      { fieldId: 'status', value: 'active' },
+    ]);
+    expect(evaluatePostSubmissionExpression("weight > 50 && status == 'active'", encounters)).toBe(true);
+    expect(evaluatePostSubmissionExpression("weight > 100 || status == 'inactive'", encounters)).toBe(false);
+  });
+
+  it('throws a generic error when the expression cannot be evaluated', () => {
+    expect(() => evaluatePostSubmissionExpression('status ===', encounterWithObs([]))).toThrow(
+      'Error evaluating expression',
+    );
+  });
+});

--- a/tools/setup-tests.ts
+++ b/tools/setup-tests.ts
@@ -1,8 +1,20 @@
 import '@testing-library/jest-dom/vitest';
-import { vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
 import ResizeObserver from 'resize-observer-polyfill';
+import { resetFormEngineModuleState } from '../src/test-support/reset';
+import { flushOpenmrsFetchRouter } from '../src/test-support/openmrs-fetch-router';
 
 global.ResizeObserver = ResizeObserver;
+
+// The engine keeps several pieces of module-level mutable state (adapter ID
+// ledgers, AST cache, registry caches/stores, page-observer singleton). Vitest
+// isolates test files, so without this, tests within a file are order-dependent:
+// a test that renders a form leaks state into the next test. The router flush also
+// fails any test whose fetches went unmatched.
+afterEach(() => {
+  resetFormEngineModuleState();
+  flushOpenmrsFetchRouter();
+});
 
 // https://github.com/jsdom/jsdom/issues/1695
 window.HTMLElement.prototype.scrollIntoView = function () {};

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,5 +7,5 @@
     "declarationDir": "dist",
     "emitDeclarationOnly": true
   },
-  "exclude": ["**/*.test.*", "**/setup-tests.*", "**/test-utils.*", "**/__mocks__/**"]
+  "exclude": ["**/*.test.*", "**/setup-tests.*", "**/test-utils.*", "**/test-support/**", "**/__mocks__/**"]
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

Medium-term plan is to do some refactoring to clean-up the form-engine library a bit and port it over to use O3Forms. In order to do so, first, though, I want to make sure to have more solid test coverage of various edge-cases. This is the first commit in a series as I'm trying to keep them somewhat reviewable (I realize 1300 lines is pushing things).

This PR adds:

* Scaffolding for future tests to build on, namely a few new testing utilities in `/test-support/`, which are excluded from the production build
* Tests for:
  * The `formStateReducer` (the core state tracking across forms)
  * The newly added test utilities
  * Various other utilities that lacked tests 
  * `evaluatePostSubmissionExpression`

It also moves the registry-cache and ast-cache into their own modules, mostly so these can be reset in the test suite without needing to import, e.g., the whole registry or the whole expression evaluation machinery.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
