### PR TITLE
(feat) O3-5945: Add annotation data type and render the Annotate button

### DIFF
--- a/__mocks__/forms/rfe-forms/annotation-test-form.json
+++ b/__mocks__/forms/rfe-forms/annotation-test-form.json
@@ -1,0 +1,92 @@
+{
+  "name": "Test Form 2",
+  "version": "1",
+  "published": true,
+  "retired": false,
+  "encounter": "Consultation",
+  "pages": [
+    {
+      "label": "Basic Data",
+      "sections": [
+        {
+          "label": "Initial Details",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Height",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "5090AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "conceptMappings": [
+                  {
+                    "type": "CIEL",
+                    "value": "5090"
+                  },
+                  {
+                    "type": "AMPATH",
+                    "value": "5090"
+                  },
+                  {
+                    "type": "PIH",
+                    "value": "5090"
+                  }
+                ]
+              },
+              "id": "Ht"
+            }
+          ]
+        },
+        {
+          "label": "Body Conditions",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "annotation",
+                "concept": "00000000-0000-0000-0000-000000000000",
+                "annotationOptions": {
+                  "templates": [
+                    {
+                      "id": "001",
+                      "label": "Template 1",
+                      "src": "https://thumb.ac-illust.com/b9/b9f175a0d667b2b826da6040256d3e07_w.jpeg"
+                    },
+                    {
+                      "id": "002",
+                      "label": "Template 2",
+                      "src": "https://thumb.ac-illust.com/b9/b9f175a0d667b2b826da6040256d3e07_w.jpeg"
+                    },
+                    {
+                      "id": "003",
+                      "label": "Template 3",
+                      "src": "https://thumb.ac-illust.com/b9/b9f175a0d667b2b826da6040256d3e07_w.jpeg"
+                    },
+                    {
+                      "id": "004",
+                      "label": "Template 4",
+                      "src": "https://thumb.ac-illust.com/b9/b9f175a0d667b2b826da6040256d3e07_w.jpeg"
+                    },
+                    {
+                      "id": "005",
+                      "label": "Template 5",
+                      "src": "https://thumb.ac-illust.com/b9/b9f175a0d667b2b826da6040256d3e07_w.jpeg"
+                    }
+                  ]
+                }
+              },
+              "id": "bodyAnnotation",
+              "label": "Annotate body on the body"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "processor": "EncounterFormProcessor",
+  "referencedForms": [],
+  "description": "test form\n",
+  "encounterType": "e22e39fd-7db2-45e7-80f1-60fa0d5a4378",
+  "uuid": "a53413bc-94fa-4659-a3c7-4a7cf2cfe6a2"
+}

--- a/src/components/inputs/annotation/annotation.component.tsx
+++ b/src/components/inputs/annotation/annotation.component.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Button } from '@carbon/react';
+import { useTranslation } from 'react-i18next';
+import { type FormFieldInputProps } from '../../../types';
+import FieldLabel from '../../field-label/field-label.component';
+import { Add } from '@carbon/react/icons';
+import { useLayoutType } from '@openmrs/esm-framework';
+import styles from './annotation.scss';
+import classNames from 'classnames';
+
+const Annotation: React.FC<FormFieldInputProps> = ({ field }) => {
+  const { t } = useTranslation();
+  const isTablet = useLayoutType() === 'tablet';
+
+  return (
+    <div>
+      <div className={classNames(styles.label, 'cds--label')}>
+        <FieldLabel field={field} />
+      </div>
+      <div>
+        <Button
+          kind={isTablet ? 'ghost' : 'tertiary'}
+          renderIcon={(props) => <Add size={16} {...props} />}>
+          {t('addAnnotation', 'Add Annotation')}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default Annotation;

--- a/src/components/inputs/annotation/annotation.scss
+++ b/src/components/inputs/annotation/annotation.scss
@@ -1,0 +1,9 @@
+@use '@carbon/layout';
+@use '@carbon/colors';
+
+.label {
+  font-weight: 600;
+  line-height: 30px;
+  color: colors.$black-100;
+}
+

--- a/src/registry/inbuilt-components/inbuiltControls.ts
+++ b/src/registry/inbuilt-components/inbuiltControls.ts
@@ -14,6 +14,7 @@ import UiSelectExtended from '../../components/inputs/ui-select-extended/ui-sele
 import WorkspaceLauncher from '../../components/inputs/workspace-launcher/workspace-launcher.component';
 import Repeat from '../../components/repeat/repeat.component';
 import File from '../../components/inputs/file/file.component';
+import Annotation from '../../components/inputs/annotation/annotation.component';
 import { type FormFieldInputProps } from '../../types';
 import { type RegistryItem } from '../registry';
 import { controlTemplates } from './control-templates';
@@ -91,6 +92,10 @@ export const inbuiltControls: Array<RegistryItem<React.ComponentType<FormFieldIn
   {
     name: 'file',
     component: File,
+  },
+  {
+    name: 'annotation',
+    component: Annotation,
   },
   ...controlTemplates.map((template) => ({
     name: template.name,

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -207,6 +207,7 @@ export interface FormQuestionOptions {
     conceptClasses?: Array<string>;
     conceptSet?: string;
   };
+  annotationOptions?: AnnotationOptions;
 }
 
 export interface QuestionAnswerOption {
@@ -215,6 +216,16 @@ export interface QuestionAnswerOption {
   label?: string;
   concept?: string;
   [key: string]: any;
+}
+
+export interface AnnotationOptions {
+  templates: Array<AnnotationTemplate>;
+}
+
+export interface AnnotationTemplate {
+  id: string;
+  label: string;
+  src: string;
 }
 
 export type RenderType =
@@ -242,7 +253,8 @@ export type RenderType =
   | 'workspace-launcher'
   | 'markdown'
   | 'extension-widget'
-  | 'select-concept-answers';
+  | 'select-concept-answers'
+  | 'annotation';
 
 export interface FormReference {
   form: string;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. PR title uses the (feat) conventional commit label.
- [x] My work is based on designs, which are linked in the Jira ticket 
- [ ] My work includes tests or is validated by existing tests.

## Summary

Part of the "Draw on a Body Diagram" epic ([O3-5941](https://openmrs.atlassian.net/browse/O3-5941)). Clinicians currently have no way to annotate body diagrams inside a clinical forms.

This PR adds the first piece of that feature to the form engine, a new `annotation` rendering type that forms can declare in their JSON schema.

Changes:

- Added an `Annotation` component for the annotation form field type, now it is showing only the Add Annotations button
- Registered the component in `inbuiltControls`.
- Added `AnnotationOptions` to the form schema types, allowing a field to declare a set of diagram templates (`id`, `label`, `src`) under `questionOptions.annotationOptions`
- Added a mock form JSON template to test the rendering

Fields using this rendering type currently render an "Add Annotation" button. Launching the annotation editor and persisting the annotated image are handled in follow-up tickets.

Example schema:

```json
{
  "id": "bodyAnnotation",
  "label": "Annotate body on the body",
  "type": "obs",
  "questionOptions": {
    "rendering": "annotation",
    "concept": "<concept-uuid>",
    "annotationOptions": {
      "templates": [
        { "id": "001", "label": "Template 1", "src": "https://..." }
      ]
    }
  }
}
```

## Screenshots

<img width="1719" height="1079" alt="Screenshot 2026-09-04 203844" src="https://github.com/user-attachments/assets/eabd6630-b89f-45d2-b6ac-d02d5f42af1b" />


The annotation field rendering in the Form Builder preview alongside the schema editor.

## Related Issue

https://openmrs.atlassian.net/browse/O3-5945

## Other

- Epic: [O3-5941 — Draw on a Body Diagram](https://openmrs.atlassian.net/browse/O3-5941)
- Wiki: https://openmrs.atlassian.net/wiki/x/EQBsTQ
- Talk thread: https://talk.openmrs.org/t/o3-draw-on-a-body-diagram-new-implementation/49754

[O3-5941]: https://openmrs.atlassian.net/browse/O3-5941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ