### PR TITLE
(fix) Form engine shouldn't create global CSS rules

### DIFF
--- a/src/components/inputs/multi-select/multi-select.scss
+++ b/src/components/inputs/multi-select/multi-select.scss
@@ -1,7 +1,7 @@
 @use '@carbon/colors';
 
 .boldedLabel label,
-legend > span {
+.boldedLabel legend > span {
   font-weight: 600;
   color: colors.$black-100;
 }

--- a/src/components/inputs/text/text.scss
+++ b/src/components/inputs/text/text.scss
@@ -10,6 +10,6 @@
   font-weight: 600;
 }
 
-:global(.cds--text-input__readonly-icon) {
+.boldedLabel :global(.cds--text-input__readonly-icon) {
   display: none;
 }

--- a/src/components/renderer/page/page.renderer.scss
+++ b/src/components/renderer/page/page.renderer.scss
@@ -69,6 +69,6 @@
 }
 
 // TODO: try removing this when upgrading @carbon/react. Added at 1.37
-:global(.cds--accordion__wrapper) {
+.sectionContainer :global(.cds--accordion__wrapper) {
   max-block-size: unset !important;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

In preparation for https://github.com/openmrs/openmrs-esm-core/pull/1869, we need to remove various CSS rules that were mistakenly targeting beyond just the form rendering

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
