### PR TITLE
(fix) Avoid redundant searches and duplicate field processing

### DIFF
--- a/src/components/inputs/ui-select-extended/ui-select-extended-search.test.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended-search.test.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
-import { useFormProviderContext } from '../../../provider/form-provider';
-import { act, fireEvent, screen, cleanup } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type OpenmrsResource } from '@openmrs/esm-framework';
-import { type DataSource } from '../../../types';
+import { type DataSource, type FormField } from '../../../types';
 import { buildField, renderWithFormContext } from '../../../test-support';
+import { useFormProviderContext } from '../../../provider/form-provider';
 import * as registry from '../../../registry/registry';
 import UiSelectExtended from './ui-select-extended.component';
+
+// These tests drive the input with fireEvent rather than userEvent. userEvent awaits a
+// setTimeout inside testing-library's async wrapper that only advances under jest's fake
+// timers, so it never resolves while vitest's fake timers are installed.
 
 const fetchData = vi.fn<DataSource<OpenmrsResource>['fetchData']>();
 const datasource: DataSource<OpenmrsResource> = {
@@ -15,15 +19,16 @@ const datasource: DataSource<OpenmrsResource> = {
   toUuidAndDisplay: (item) => item,
 };
 
-function Connected({ field }: Pick<React.ComponentProps<typeof UiSelectExtended>, 'field'>) {
+function Connected({ field }: { field: FormField }) {
   const { methods } = useFormProviderContext();
+
   return (
     <UiSelectExtended
       field={field}
       value={null}
       errors={[]}
       warnings={[]}
-      setFieldValue={(v) => methods.setValue(field.id, v, { shouldDirty: true })}
+      setFieldValue={(value) => methods.setValue(field.id, value, { shouldDirty: true })}
     />
   );
 }
@@ -42,7 +47,12 @@ async function renderSearch(initialValue = '') {
     initialValues: { provider: initialValue },
   });
   await act(async () => {});
+
   return { ...result, field };
+}
+
+function type(value: string) {
+  fireEvent.change(screen.getByRole('combobox'), { target: { value } });
 }
 
 async function advance(ms: number) {
@@ -58,7 +68,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  cleanup();
   vi.useRealTimers();
   vi.restoreAllMocks();
 });
@@ -66,36 +75,40 @@ afterEach(() => {
 describe('search request lifetime', () => {
   it('searches once after rapid typing, using the latest term', async () => {
     await renderSearch();
+
     for (const value of ['m', 'ma', 'mal', 'mala']) {
-      fireEvent.change(screen.getByRole('combobox'), { target: { value } });
+      type(value);
       await advance(40);
     }
     expect(fetchData).not.toHaveBeenCalled();
     await advance(300);
+
     expect(fetchData).toHaveBeenCalledExactlyOnceWith('mala', { tag: 'initial' });
   });
 
   it('cancels a pending search when the query is cleared', async () => {
     await renderSearch();
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'mal' } });
+
+    type('mal');
     await advance(100);
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: '' } });
+    type('');
     await advance(300);
+
     expect(fetchData).not.toHaveBeenCalled();
   });
 
   it('cancels a pending search when unmounted', async () => {
     const { unmount } = await renderSearch();
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'mal' } });
+
+    type('mal');
     unmount();
     await advance(300);
+
     expect(fetchData).not.toHaveBeenCalled();
   });
 
   it('uses updated configuration when a pending search is replaced', async () => {
     const { rerender, field } = await renderSearch();
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'mal' } });
-    await advance(100);
     const updatedField = {
       ...field,
       questionOptions: {
@@ -103,8 +116,12 @@ describe('search request lifetime', () => {
         datasource: { name: 'provider', config: { tag: 'updated' } },
       },
     };
+
+    type('mal');
+    await advance(100);
     rerender(<Connected field={updatedField} />);
     await advance(300);
+
     expect(fetchData).toHaveBeenCalledExactlyOnceWith('mal', { tag: 'updated' });
   });
 
@@ -112,8 +129,10 @@ describe('search request lifetime', () => {
     vi.mocked(datasource.fetchSingleItem).mockResolvedValue({ uuid: 'selected', display: 'Selected provider' });
     fetchData.mockResolvedValue([{ uuid: 'new', display: 'New provider' }]);
     await renderSearch('selected');
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'new' } });
+
+    type('new');
     await advance(300);
+
     expect(screen.getByText('New provider')).toBeInTheDocument();
     expect(screen.getByText('Selected provider')).toBeInTheDocument();
   });
@@ -127,59 +146,68 @@ describe('search request lifetime', () => {
     );
     fetchData.mockResolvedValueOnce([{ uuid: 'new', display: 'New provider' }]);
     await renderSearch();
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'old' } });
+
+    type('old');
     await advance(300);
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'new' } });
+    type('new');
     await advance(300);
     expect(screen.getByText('New provider')).toBeInTheDocument();
     await act(async () => {
       resolveOld([{ uuid: 'old', display: 'Old provider' }]);
     });
+
     expect(screen.getByText('New provider')).toBeInTheDocument();
     expect(screen.queryByText('Old provider')).not.toBeInTheDocument();
   });
-});
 
-it('selection does not repeat a resolved synonym search', async () => {
-  fetchData.mockResolvedValue([{ uuid: 'acet', display: 'Acetaminophen' }]);
-  await renderSearch();
-  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'para' } });
-  await advance(300);
-  fireEvent.click(screen.getByRole('option', { name: 'Acetaminophen' }));
-  await advance(350);
-  expect(fetchData).toHaveBeenCalledTimes(1);
-});
-it('selection invalidates an already in-flight search', async () => {
-  let finish: (items: OpenmrsResource[]) => void;
-  fetchData.mockResolvedValueOnce([{ uuid: 'malaria', display: 'Malaria' }]);
-  fetchData.mockReturnValueOnce(
-    new Promise((resolve) => {
-      finish = resolve;
-    }),
-  );
-  await renderSearch();
-  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'ma' } });
-  await advance(300);
-  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'malx' } });
-  await advance(300);
-  fireEvent.click(screen.getByRole('option', { name: 'Malaria' }));
-  await act(async () => {
-    finish([{ uuid: 'unrelated', display: 'Unrelated result' }]);
+  it('does not repeat a resolved search when a synonym match is selected', async () => {
+    fetchData.mockResolvedValue([{ uuid: 'acet', display: 'Acetaminophen' }]);
+    await renderSearch();
+
+    type('para');
+    await advance(300);
+    fireEvent.click(screen.getByRole('option', { name: 'Acetaminophen' }));
+    await advance(350);
+
+    expect(fetchData).toHaveBeenCalledTimes(1);
   });
-  fireEvent.click(screen.getByRole('button', { name: 'Open' }));
-  expect(screen.queryByRole('option', { name: 'Unrelated result' })).not.toBeInTheDocument();
-  expect(screen.queryByText('Searching...')).not.toBeInTheDocument();
-});
 
-it('cancels a pending search when an item is selected', async () => {
-  fetchData.mockResolvedValue([{ uuid: 'malaria', display: 'Malaria' }]);
-  await renderSearch();
-  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'ma' } });
-  await advance(300);
-  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'malx' } });
-  await advance(100);
-  fireEvent.click(screen.getByRole('option', { name: 'Malaria' }));
-  await advance(350);
-  expect(fetchData).toHaveBeenCalledExactlyOnceWith('ma', { tag: 'initial' });
-  expect(screen.getByRole('combobox')).toHaveValue('Malaria');
+  it('invalidates an in-flight search when an item is selected', async () => {
+    let resolveInFlight: (items: OpenmrsResource[]) => void;
+    fetchData.mockResolvedValueOnce([{ uuid: 'malaria', display: 'Malaria' }]);
+    fetchData.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveInFlight = resolve;
+      }),
+    );
+    await renderSearch();
+
+    type('ma');
+    await advance(300);
+    type('malx');
+    await advance(300);
+    fireEvent.click(screen.getByRole('option', { name: 'Malaria' }));
+    await act(async () => {
+      resolveInFlight([{ uuid: 'unrelated', display: 'Unrelated result' }]);
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+
+    expect(screen.queryByRole('option', { name: 'Unrelated result' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Searching...')).not.toBeInTheDocument();
+  });
+
+  it('cancels a pending search when an item is selected', async () => {
+    fetchData.mockResolvedValue([{ uuid: 'malaria', display: 'Malaria' }]);
+    await renderSearch();
+
+    type('ma');
+    await advance(300);
+    type('malx');
+    await advance(100);
+    fireEvent.click(screen.getByRole('option', { name: 'Malaria' }));
+    await advance(350);
+
+    expect(fetchData).toHaveBeenCalledExactlyOnceWith('ma', { tag: 'initial' });
+    expect(screen.getByRole('combobox')).toHaveValue('Malaria');
+  });
 });

--- a/src/components/inputs/ui-select-extended/ui-select-extended-search.test.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended-search.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useFormProviderContext } from '../../../provider/form-provider';
 import { act, fireEvent, screen, cleanup } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type OpenmrsResource } from '@openmrs/esm-framework';
@@ -14,6 +15,19 @@ const datasource: DataSource<OpenmrsResource> = {
   toUuidAndDisplay: (item) => item,
 };
 
+function Connected({ field }: Pick<React.ComponentProps<typeof UiSelectExtended>, 'field'>) {
+  const { methods } = useFormProviderContext();
+  return (
+    <UiSelectExtended
+      field={field}
+      value={null}
+      errors={[]}
+      warnings={[]}
+      setFieldValue={(v) => methods.setValue(field.id, v, { shouldDirty: true })}
+    />
+  );
+}
+
 async function renderSearch(initialValue = '') {
   const field = buildField({
     id: 'provider',
@@ -23,10 +37,10 @@ async function renderSearch(initialValue = '') {
       datasource: { name: 'provider', config: { tag: 'initial' } },
     },
   });
-  const result = renderWithFormContext(
-    <UiSelectExtended field={field} value={null} errors={[]} warnings={[]} setFieldValue={vi.fn()} />,
-    { fields: [field], initialValues: { provider: initialValue } },
-  );
+  const result = renderWithFormContext(<Connected field={field} />, {
+    fields: [field],
+    initialValues: { provider: initialValue },
+  });
   await act(async () => {});
   return { ...result, field };
 }
@@ -89,7 +103,7 @@ describe('search request lifetime', () => {
         datasource: { name: 'provider', config: { tag: 'updated' } },
       },
     };
-    rerender(<UiSelectExtended field={updatedField} value={null} errors={[]} warnings={[]} setFieldValue={vi.fn()} />);
+    rerender(<Connected field={updatedField} />);
     await advance(300);
     expect(fetchData).toHaveBeenCalledExactlyOnceWith('mal', { tag: 'updated' });
   });
@@ -124,4 +138,48 @@ describe('search request lifetime', () => {
     expect(screen.getByText('New provider')).toBeInTheDocument();
     expect(screen.queryByText('Old provider')).not.toBeInTheDocument();
   });
+});
+
+it('selection does not repeat a resolved synonym search', async () => {
+  fetchData.mockResolvedValue([{ uuid: 'acet', display: 'Acetaminophen' }]);
+  await renderSearch();
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'para' } });
+  await advance(300);
+  fireEvent.click(screen.getByRole('option', { name: 'Acetaminophen' }));
+  await advance(350);
+  expect(fetchData).toHaveBeenCalledTimes(1);
+});
+it('selection invalidates an already in-flight search', async () => {
+  let finish: (items: OpenmrsResource[]) => void;
+  fetchData.mockResolvedValueOnce([{ uuid: 'malaria', display: 'Malaria' }]);
+  fetchData.mockReturnValueOnce(
+    new Promise((resolve) => {
+      finish = resolve;
+    }),
+  );
+  await renderSearch();
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'ma' } });
+  await advance(300);
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'malx' } });
+  await advance(300);
+  fireEvent.click(screen.getByRole('option', { name: 'Malaria' }));
+  await act(async () => {
+    finish([{ uuid: 'unrelated', display: 'Unrelated result' }]);
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+  expect(screen.queryByRole('option', { name: 'Unrelated result' })).not.toBeInTheDocument();
+  expect(screen.queryByText('Searching...')).not.toBeInTheDocument();
+});
+
+it('cancels a pending search when an item is selected', async () => {
+  fetchData.mockResolvedValue([{ uuid: 'malaria', display: 'Malaria' }]);
+  await renderSearch();
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'ma' } });
+  await advance(300);
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'malx' } });
+  await advance(100);
+  fireEvent.click(screen.getByRole('option', { name: 'Malaria' }));
+  await advance(350);
+  expect(fetchData).toHaveBeenCalledExactlyOnceWith('ma', { tag: 'initial' });
+  expect(screen.getByRole('combobox')).toHaveValue('Malaria');
 });

--- a/src/components/inputs/ui-select-extended/ui-select-extended-search.test.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended-search.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { act, fireEvent, screen, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type OpenmrsResource } from '@openmrs/esm-framework';
+import { type DataSource } from '../../../types';
+import { buildField, renderWithFormContext } from '../../../test-support';
+import * as registry from '../../../registry/registry';
+import UiSelectExtended from './ui-select-extended.component';
+
+const fetchData = vi.fn<DataSource<OpenmrsResource>['fetchData']>();
+const datasource: DataSource<OpenmrsResource> = {
+  fetchData,
+  fetchSingleItem: vi.fn(),
+  toUuidAndDisplay: (item) => item,
+};
+
+async function renderSearch(initialValue = '') {
+  const field = buildField({
+    id: 'provider',
+    questionOptions: {
+      rendering: 'ui-select-extended',
+      isSearchable: true,
+      datasource: { name: 'provider', config: { tag: 'initial' } },
+    },
+  });
+  const result = renderWithFormContext(
+    <UiSelectExtended field={field} value={null} errors={[]} warnings={[]} setFieldValue={vi.fn()} />,
+    { fields: [field], initialValues: { provider: initialValue } },
+  );
+  await act(async () => {});
+  return { ...result, field };
+}
+
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fetchData.mockReset().mockResolvedValue([]);
+  vi.spyOn(registry, 'getRegisteredDataSource').mockResolvedValue(datasource);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('search request lifetime', () => {
+  it('searches once after rapid typing, using the latest term', async () => {
+    await renderSearch();
+    for (const value of ['m', 'ma', 'mal', 'mala']) {
+      fireEvent.change(screen.getByRole('combobox'), { target: { value } });
+      await advance(40);
+    }
+    expect(fetchData).not.toHaveBeenCalled();
+    await advance(300);
+    expect(fetchData).toHaveBeenCalledExactlyOnceWith('mala', { tag: 'initial' });
+  });
+
+  it('cancels a pending search when the query is cleared', async () => {
+    await renderSearch();
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'mal' } });
+    await advance(100);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '' } });
+    await advance(300);
+    expect(fetchData).not.toHaveBeenCalled();
+  });
+
+  it('cancels a pending search when unmounted', async () => {
+    const { unmount } = await renderSearch();
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'mal' } });
+    unmount();
+    await advance(300);
+    expect(fetchData).not.toHaveBeenCalled();
+  });
+
+  it('uses updated configuration when a pending search is replaced', async () => {
+    const { rerender, field } = await renderSearch();
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'mal' } });
+    await advance(100);
+    const updatedField = {
+      ...field,
+      questionOptions: {
+        ...field.questionOptions,
+        datasource: { name: 'provider', config: { tag: 'updated' } },
+      },
+    };
+    rerender(<UiSelectExtended field={updatedField} value={null} errors={[]} warnings={[]} setFieldValue={vi.fn()} />);
+    await advance(300);
+    expect(fetchData).toHaveBeenCalledExactlyOnceWith('mal', { tag: 'updated' });
+  });
+
+  it('retains the selected item when new search results arrive', async () => {
+    vi.mocked(datasource.fetchSingleItem).mockResolvedValue({ uuid: 'selected', display: 'Selected provider' });
+    fetchData.mockResolvedValue([{ uuid: 'new', display: 'New provider' }]);
+    await renderSearch('selected');
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'new' } });
+    await advance(300);
+    expect(screen.getByText('New provider')).toBeInTheDocument();
+    expect(screen.getByText('Selected provider')).toBeInTheDocument();
+  });
+
+  it('ignores an older response that arrives after the current search', async () => {
+    let resolveOld: (items: OpenmrsResource[]) => void;
+    fetchData.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveOld = resolve;
+      }),
+    );
+    fetchData.mockResolvedValueOnce([{ uuid: 'new', display: 'New provider' }]);
+    await renderSearch();
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'old' } });
+    await advance(300);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'new' } });
+    await advance(300);
+    expect(screen.getByText('New provider')).toBeInTheDocument();
+    await act(async () => {
+      resolveOld([{ uuid: 'old', display: 'Old provider' }]);
+    });
+    expect(screen.getByText('New provider')).toBeInTheDocument();
+    expect(screen.queryByText('Old provider')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -48,6 +48,11 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
   const selectedItem = useMemo(() => items.find((item) => item.uuid == value) || null, [items, value]);
 
   const searchGeneration = useRef(0);
+  const valueRef = useRef(value);
+
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
 
   const debouncedSearch = useMemo(
     () =>
@@ -63,7 +68,7 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
             }
             if (dataItems.length) {
               setItems((currentItems) => {
-                const currentSelectedItem = currentItems.find((item) => item.uuid == value);
+                const currentSelectedItem = currentItems.find((item) => item.uuid == valueRef.current);
                 const newItems = dataItems.map((item) => dataSource.toUuidAndDisplay(item, config));
                 if (currentSelectedItem && !newItems.some((item) => item.uuid == currentSelectedItem.uuid)) {
                   newItems.unshift(currentSelectedItem);
@@ -81,7 +86,7 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
             setIsSearching(false);
           });
       }, 300),
-    [config, value],
+    [config],
   );
 
   const searchTermHasMatchingItem = useCallback(
@@ -198,6 +203,9 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
             selectedItem={selectedItem}
             placeholder={isSearchable ? t('search', 'Search') + '...' : null}
             onChange={({ selectedItem }) => {
+              debouncedSearch.cancel();
+              searchGeneration.current++;
+              setIsSearching(false);
               isProcessingSelection.current = true;
               setFieldValue(selectedItem?.uuid);
             }}

--- a/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.component.tsx
@@ -47,27 +47,42 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
 
   const selectedItem = useMemo(() => items.find((item) => item.uuid == value) || null, [items, value]);
 
-  const debouncedSearch = debounce((searchTerm: string, dataSource: DataSource<OpenmrsResource>) => {
-    setIsSearching(true);
+  const searchGeneration = useRef(0);
 
-    dataSource
-      .fetchData(searchTerm, config)
-      .then((dataItems) => {
-        if (dataItems.length) {
-          const currentSelectedItem = items.find((item) => item.uuid == value);
-          const newItems = dataItems.map((item) => dataSource.toUuidAndDisplay(item, config));
-          if (currentSelectedItem && !newItems.some((item) => item.uuid == currentSelectedItem.uuid)) {
-            newItems.unshift(currentSelectedItem);
-          }
-          setItems(newItems);
-        }
-        setIsSearching(false);
-      })
-      .catch((err) => {
-        console.error(err);
-        setIsSearching(false);
-      });
-  }, 300);
+  const debouncedSearch = useMemo(
+    () =>
+      debounce((searchTerm: string, dataSource: DataSource<OpenmrsResource>) => {
+        const generation = searchGeneration.current;
+        setIsSearching(true);
+
+        dataSource
+          .fetchData(searchTerm, config)
+          .then((dataItems) => {
+            if (generation !== searchGeneration.current) {
+              return;
+            }
+            if (dataItems.length) {
+              setItems((currentItems) => {
+                const currentSelectedItem = currentItems.find((item) => item.uuid == value);
+                const newItems = dataItems.map((item) => dataSource.toUuidAndDisplay(item, config));
+                if (currentSelectedItem && !newItems.some((item) => item.uuid == currentSelectedItem.uuid)) {
+                  newItems.unshift(currentSelectedItem);
+                }
+                return newItems;
+              });
+            }
+            setIsSearching(false);
+          })
+          .catch((err) => {
+            if (generation !== searchGeneration.current) {
+              return;
+            }
+            console.error(err);
+            setIsSearching(false);
+          });
+      }, 300),
+    [config, value],
+  );
 
   const searchTermHasMatchingItem = useCallback(
     (searchTerm: string) => {
@@ -119,8 +134,14 @@ const UiSelectExtended: React.FC<FormFieldInputProps> = ({ field, errors, warnin
   useEffect(() => {
     if (dataSource && isSearchable && !isEmpty(searchTerm) && !searchTermHasMatchingItem(searchTerm)) {
       debouncedSearch(searchTerm, dataSource);
+    } else {
+      setIsSearching(false);
     }
-  }, [dataSource, searchTerm, config]);
+    return () => {
+      debouncedSearch.cancel();
+      searchGeneration.current++;
+    };
+  }, [dataSource, searchTerm, isSearchable, debouncedSearch]);
 
   useEffect(() => {
     let ignore = false;

--- a/src/components/inputs/ui-select-extended/ui-select-extended.test.tsx
+++ b/src/components/inputs/ui-select-extended/ui-select-extended.test.tsx
@@ -16,13 +16,6 @@ const mockUsePatient = vi.mocked(usePatient);
 const mockUseSession = vi.mocked(useSession);
 const mockOpenmrsFetch = vi.mocked(openmrsFetch);
 
-vi.mock('lodash-es/debounce', () => vi.fn((fn) => fn));
-
-vi.mock('lodash-es', async () => ({
-  ...((await vi.importActual('lodash-es')) as object),
-  debounce: vi.fn((fn) => fn),
-}));
-
 vi.mock('../../../api', async () => {
   const originalModule = (await vi.importActual('../../../api')) as object;
   return {

--- a/src/components/renderer/field/form-field-renderer.component.tsx
+++ b/src/components/renderer/field/form-field-renderer.component.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { isEqual } from 'lodash-es';
 import { ToastNotification } from '@carbon/react';
 import { Controller, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -66,6 +67,7 @@ export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: Form
     updateFormField,
   } = context;
 
+  const pendingChange = useRef<{ value: unknown } | null>(null);
   const fieldValue = useWatch({ control, name: fieldId, exact: true });
   const noop = () => {};
 
@@ -109,7 +111,10 @@ export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: Form
     ) {
       valueAdapter.transformFieldValue(field, fieldValue, context);
     }
-    if (isDirty || isTouched) {
+    // Controls already process changes synchronously; the watcher also handles external updates.
+    const processedChange = pendingChange.current;
+    pendingChange.current = null;
+    if ((isDirty || isTouched) && (!processedChange || !isEqual(processedChange.value, fieldValue))) {
       onAfterChange(fieldValue);
     }
   }, [fieldValue]);
@@ -171,6 +176,11 @@ export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: Form
     }
   };
 
+  const handleAfterChange = (value: unknown) => {
+    pendingChange.current = { value };
+    onAfterChange(value);
+  };
+
   if (!inputComponentWrapper) {
     return null;
   }
@@ -218,7 +228,7 @@ export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: Form
               warnings={warnings}
               setFieldValue={(val) => {
                 onChange(val);
-                onAfterChange(val);
+                handleAfterChange(val);
                 onBlur();
               }}
             />
@@ -229,7 +239,7 @@ export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: Form
                     key={`${field.id}-unspecified`}
                     field={field}
                     setFieldValue={onChange}
-                    onAfterChange={onAfterChange}
+                    onAfterChange={handleAfterChange}
                     fieldValue={value}
                   />
                 )}
@@ -241,7 +251,7 @@ export const FormFieldRenderer = ({ fieldId, valueAdapter, repeatOptions }: Form
                   key={`${field.id}-previous-value-review`}
                   previousValue={historicalValue.value}
                   displayText={historicalValue.display}
-                  onAfterChange={onAfterChange}
+                  onAfterChange={handleAfterChange}
                   field={field}
                 />
               </div>

--- a/src/components/renderer/field/form-field-renderer.test.tsx
+++ b/src/components/renderer/field/form-field-renderer.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildField, renderWithFormContext, createTestFormContext } from '../../../test-support';
+import { ObsAdapter } from '../../../adapters/obs-adapter';
+import * as fieldLogic from './fieldLogic';
+import { FormFieldRenderer } from './form-field-renderer.component';
+
+afterEach(() => vi.restoreAllMocks());
+
+function observeChanges() {
+  return {
+    validate: vi.spyOn(fieldLogic, 'validateFieldValue'),
+    transform: vi.spyOn(ObsAdapter, 'transformFieldValue'),
+    logic: vi.spyOn(fieldLogic, 'handleFieldLogic'),
+  };
+}
+
+function expectChanges(spies: ReturnType<typeof observeChanges>, count: number) {
+  expect(spies.validate).toHaveBeenCalledTimes(count);
+  expect(spies.transform).toHaveBeenCalledTimes(count);
+  expect(spies.logic).toHaveBeenCalledTimes(count);
+}
+
+describe('field change processing', () => {
+  it('processes each typed value once and still processes external updates', async () => {
+    const field = buildField({ id: 'remarks' });
+    const { getContext } = renderWithFormContext(<FormFieldRenderer fieldId={field.id} valueAdapter={ObsAdapter} />, {
+      fields: [field],
+      initialValues: { remarks: '' },
+    });
+    const input = await screen.findByRole('textbox');
+    const spies = observeChanges();
+    const user = userEvent.setup();
+    await user.type(input, 'abc');
+    expectChanges(spies, 3);
+    expect(getContext().methods.getValues('remarks')).toBe('abc');
+    await act(async () => {
+      getContext().methods.setValue('remarks', 'calculated');
+    });
+    expectChanges(spies, 4);
+    expect(input).toHaveValue('calculated');
+  });
+
+  it('processes checkbox array values once even when react-hook-form clones them', async () => {
+    const field = buildField({
+      id: 'answers',
+      questionOptions: {
+        rendering: 'checkbox',
+        answers: [
+          { concept: 'yes', label: 'Yes' },
+          { concept: 'no', label: 'No' },
+        ],
+      },
+    });
+    renderWithFormContext(<FormFieldRenderer fieldId={field.id} valueAdapter={ObsAdapter} />, {
+      fields: [field],
+      initialValues: { answers: [] },
+    });
+    const checkbox = await screen.findByRole('checkbox', { name: 'Yes' });
+    const spies = observeChanges();
+    await userEvent.setup().click(checkbox);
+    expectChanges(spies, 1);
+  });
+
+  it.each([false, true])('processes a reused historical value once (touched: %s)', async (touched) => {
+    const field = buildField({ id: 'remarks', historicalExpression: '"previous"' });
+    const processor = createTestFormContext().processor;
+    vi.spyOn(processor, 'getHistoricalValue').mockResolvedValue({ value: 'previous', display: 'Previous remarks' });
+    renderWithFormContext(<FormFieldRenderer fieldId={field.id} valueAdapter={ObsAdapter} />, {
+      fields: [field],
+      initialValues: { remarks: '' },
+      context: { processor },
+    });
+    const user = userEvent.setup();
+    const input = await screen.findByRole('textbox');
+    if (touched) {
+      await user.type(input, 'a');
+    }
+    const spies = observeChanges();
+    await user.click(screen.getByRole('button', { name: 'Reuse value' }));
+    expectChanges(spies, 1);
+    expect(screen.getByRole('textbox')).toHaveValue('previous');
+  });
+
+  it('processes clearing an unspecified field once', async () => {
+    const field = buildField({ id: 'remarks', unspecified: true });
+    renderWithFormContext(<FormFieldRenderer fieldId={field.id} valueAdapter={ObsAdapter} />, {
+      fields: [field],
+      initialValues: { remarks: '' },
+    });
+    const user = userEvent.setup();
+    await user.type(await screen.findByRole('textbox'), 'a');
+    const spies = observeChanges();
+    await user.click(screen.getByRole('checkbox', { name: 'Unspecified' }));
+    expectChanges(spies, 1);
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+});

--- a/src/form-engine.test.tsx
+++ b/src/form-engine.test.tsx
@@ -88,13 +88,6 @@ when(mockOpenmrsFetch)
   .calledWith(clobDataResourcePath)
   .mockReturnValue({ data: demoHtsForm } as never);
 
-vi.mock('lodash-es/debounce', () => vi.fn((fn) => fn));
-
-vi.mock('lodash-es', async () => ({
-  ...((await vi.importActual('lodash-es')) as object),
-  debounce: vi.fn((fn) => fn),
-}));
-
 vi.mock('./registry/registry', async () => {
   const originalModule = (await vi.importActual('./registry/registry')) as object;
   return {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Rapid typing in searchable selects creates a new debounced function on each render, allowing several searches to run for one typing burst. Keep the debounced function stable, cancel pending searches when superseded, on item selection, or on unmount, and ignore responses from obsolete searches. Preserve the selected item when new results arrive.

Field controls also process changes immediately and then process the same value again through the form-state watcher. Track the value already processed by the control so the watcher skips that duplicate while continuing to handle programmatic updates. This also covers checkbox arrays, historical-value reuse, and clearing unspecified fields.

## Screenshots

Form Builder UI with counters around the actual engine functions and the local provider datasource. Typing `abc` reduced validation, transformation, and field-logic calls from six each to three each. Rapidly typing `mala` reduced provider searches from three to one in that UI run.

### Before

https://github.com/user-attachments/assets/6b352324-0faf-4cde-b31b-fc6a1cb73b00

### After

https://github.com/user-attachments/assets/9c552d61-f2f9-4b14-a088-142dd36c1edd

## Related Issue

## Other

This PR adds 14 regression cases covering debounce timing, query clearing, unmounting, configuration changes, selected-item preservation, stale responses, selection after synonym matches, pending and in-flight searches at selection, text entry, external updates, checkbox arrays, historical-value reuse, and unspecified fields. It also removes debounce mocks that bypassed the real behaviour.
